### PR TITLE
Fix MSI Creation error

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -181,7 +181,7 @@ Task MSI {
     Copy-Item -Path ".\src\Configuration\$Configuration\Hadouken.exe.msi.config" -Destination $configTarget
 
     Exec {
-        & $Tools_WixCandle "-dBinDir=$Dir_Binaries" "-dBuildVersion=$Version" -dConfigDir=src\Configuration\Service -ext WixUtilExtension -ext WixFirewallExtension -o "$Dir_Artifacts\wixobj\" $wxs
+        & $Tools_WixCandle "-dBinDir=$Dir_Binaries" "-dBuildVersion=$Version" -dConfigDir=src\Configuration\Service -ext WixUtilExtension -ext WixFirewallExtension -o "$Dir_Artifacts\wixobj\\" $wxs
     }
 
     $wixobj = Get-ChildItem "$Dir_Artifacts\wixobj\" -Include *.wixobj -Recurse | Select-Object FullName | foreach {$_.FullName}


### PR DESCRIPTION
Receiving an error from candle when running the build script. Issue only occurs if there is a space in the project path.

error CNDL0117 : Your file or directory path 'C:\Users\Basement\Documents\Visual Studio 2013\Projects\hadouken\build\wixobj" C:\Users\Basement\Documents\Visual' cannot contain a quote. Quotes are often accidentally introduced when trying to refer to a directory path with spaces in it, such as "C:\Out Directory\". The correct representation for that path is: "C:\Out Directory\".

I was able to fix the error by adding the extra backslash. I tested the new script in a project folder with spaces and without and it worked.
