### PR TITLE
Added VS toolset version to cmake command line

### DIFF
--- a/win32/build.cake
+++ b/win32/build.cake
@@ -114,7 +114,7 @@ Task("Generate-CMake-Project")
         var cmakeExitCode = StartProcess("cmake",
             new ProcessSettings
             {
-                Arguments = "../../",
+                Arguments = "../../ -G \"Visual Studio 12\" -T \"v120\"",
                 WorkingDirectory = "./build"
             });
 


### PR DESCRIPTION
When having different versions of VS installed, there can be a problem with cmake when the toolset is not explicitly specified.