### PR TITLE
[WIP] Implementing all alerts from libtorrent as events

### DIFF
--- a/include/Hadouken/BitTorrent/Error.hpp
+++ b/include/Hadouken/BitTorrent/Error.hpp
@@ -1,0 +1,24 @@
+#ifndef HADOUKEN_BITTORRENT_ERROR_HPP
+#define HADOUKEN_BITTORRENT_ERROR_HPP
+
+#include <string>
+
+namespace Hadouken
+{
+    namespace BitTorrent
+    {
+        struct Error
+        {
+            Error(int errorCode, std::string message)
+                : code(errorCode),
+                message(message)
+            {
+            }
+
+            const int code;
+            const std::string message;
+        };
+    }
+}
+
+#endif

--- a/include/Hadouken/BitTorrent/Session.hpp
+++ b/include/Hadouken/BitTorrent/Session.hpp
@@ -22,6 +22,7 @@ namespace libtorrent
     struct lazy_entry;
     class session;
     class sha1_hash;
+    struct torrent_handle;
     class torrent_info;
 }
 
@@ -69,9 +70,15 @@ namespace Hadouken
 
             HDKN_EXPORT void pause();
 
-            void removeTorrent(const std::shared_ptr<TorrentHandle>& handle, int options = 0) const;
+            void removeTorrent(std::shared_ptr<TorrentHandle> handle, int options = 0) const;
 
             HDKN_EXPORT void resume();
+
+            HDKN_EXPORT std::string getTorrentMetadata(std::string infoHash, std::string key);
+
+            HDKN_EXPORT std::vector<std::string> getTorrentMetadataKeys(std::string infoHash);
+
+            HDKN_EXPORT void setTorrentMetadata(std::string infoHash, std::string key, std::string value);
 
             void setProxy(ProxySettings& proxy);
 
@@ -84,11 +91,11 @@ namespace Hadouken
         protected:
             void loadSessionState();
             void loadResumeData();
-            void loadHadoukenState(std::shared_ptr<TorrentHandle> handle, const libtorrent::lazy_entry& entry);
+            void loadHadoukenState(const libtorrent::torrent_handle& handle, const libtorrent::lazy_entry& entry);
 
             void saveSessionState();
             void saveResumeData();
-            void saveHadoukenState(std::shared_ptr<TorrentHandle> handle, libtorrent::dictionary_type& entry);
+            void saveHadoukenState(const libtorrent::torrent_handle& handle, libtorrent::dictionary_type& entry);
 
             void readAlerts();
 
@@ -99,11 +106,10 @@ namespace Hadouken
             Poco::Path getTorrentsPath();
 
         private:
-            std::map<libtorrent::sha1_hash, std::shared_ptr<TorrentHandle>> torrents_;
-
             Poco::Logger& logger_;
             const Poco::Util::AbstractConfiguration& config_;
             std::unique_ptr<libtorrent::session> sess_;
+            std::map<std::string, std::map<std::string, std::string>> torrentMetadata_;
 
             // default settings
             std::string default_save_path_;

--- a/include/Hadouken/BitTorrent/TorrentHandle.hpp
+++ b/include/Hadouken/BitTorrent/TorrentHandle.hpp
@@ -3,6 +3,7 @@
 
 #include <Hadouken/Config.hpp>
 #include <libtorrent/torrent_handle.hpp>
+#include <map>
 #include <string>
 
 namespace Hadouken
@@ -62,14 +63,6 @@ namespace Hadouken
             HDKN_EXPORT void renameFile(int index, std::string const& name) const;
 
             HDKN_EXPORT void resume() const;
-
-            HDKN_EXPORT std::vector<std::string> getDataKeys();
-
-            HDKN_EXPORT std::string getData(std::string key);
-
-            HDKN_EXPORT void setData(std::string key, std::string value);
-
-            HDKN_EXPORT void clearData(std::string key);
 
             HDKN_EXPORT void queueBottom() const;
 

--- a/include/Hadouken/Scripting/Modules/BitTorrent/Events/BlockEvent.hpp
+++ b/include/Hadouken/Scripting/Modules/BitTorrent/Events/BlockEvent.hpp
@@ -1,0 +1,41 @@
+#ifndef HADOUKEN_SCRIPTING_MODULES_BITTORRENT_EVENTS_BLOCKEVENT_HPP
+#define HADOUKEN_SCRIPTING_MODULES_BITTORRENT_EVENTS_BLOCKEVENT_HPP
+
+#include <Hadouken/Scripting/Modules/BitTorrent/Events/PeerEvent.hpp>
+
+#include <memory>
+#include <string>
+
+namespace Hadouken
+{
+    namespace BitTorrent
+    {
+        struct TorrentHandle;
+    }
+
+    namespace Scripting
+    {
+        namespace Modules
+        {
+            namespace BitTorrent
+            {
+                namespace Events
+                {
+                    class BlockEvent : public PeerEvent
+                    {
+                    public:
+                        BlockEvent(std::shared_ptr<Hadouken::BitTorrent::TorrentHandle> handle, std::string ip, int port, int pieceIndex, int blockIndex);
+
+                        void push(void* ctx);
+
+                    private:
+                        int pieceIndex_;
+                        int blockIndex_;
+                    };
+                }
+            }
+        }
+    }
+}
+
+#endif

--- a/include/Hadouken/Scripting/Modules/BitTorrent/Events/DhtReplyEvent.hpp
+++ b/include/Hadouken/Scripting/Modules/BitTorrent/Events/DhtReplyEvent.hpp
@@ -1,0 +1,40 @@
+#ifndef HADOUKEN_SCRIPTING_MODULES_BITTORRENT_EVENTS_DHTREPLYEVENT_HPP
+#define HADOUKEN_SCRIPTING_MODULES_BITTORRENT_EVENTS_DHTREPLYEVENT_HPP
+
+#include <Hadouken/Scripting/Modules/BitTorrent/Events/TrackerEvent.hpp>
+
+#include <memory>
+#include <string>
+
+namespace Hadouken
+{
+    namespace BitTorrent
+    {
+        struct TorrentHandle;
+    }
+
+    namespace Scripting
+    {
+        namespace Modules
+        {
+            namespace BitTorrent
+            {
+                namespace Events
+                {
+                    class DhtReplyEvent : public TrackerEvent
+                    {
+                    public:
+                        DhtReplyEvent(std::shared_ptr<Hadouken::BitTorrent::TorrentHandle> handle, std::string url, int numPeers);
+
+                        void push(void* ctx);
+
+                    private:
+                        int numPeers_;
+                    };
+                }
+            }
+        }
+    }
+}
+
+#endif

--- a/include/Hadouken/Scripting/Modules/BitTorrent/Events/EmptyEvent.hpp
+++ b/include/Hadouken/Scripting/Modules/BitTorrent/Events/EmptyEvent.hpp
@@ -1,0 +1,27 @@
+#ifndef HADOUKEN_SCRIPTING_MODULES_BITTORRENT_EVENTS_EMPTYEVENT_HPP
+#define HADOUKEN_SCRIPTING_MODULES_BITTORRENT_EVENTS_EMPTYEVENT_HPP
+
+#include <Hadouken/Scripting/Event.hpp>
+
+namespace Hadouken
+{
+    namespace Scripting
+    {
+        namespace Modules
+        {
+            namespace BitTorrent
+            {
+                namespace Events
+                {
+                    class EmptyEvent : public Event
+                    {
+                    public:
+                        void push(void* ctx);
+                    };
+                }
+            }
+        }
+    }
+}
+
+#endif

--- a/include/Hadouken/Scripting/Modules/BitTorrent/Events/EmptyPeerEvent.hpp
+++ b/include/Hadouken/Scripting/Modules/BitTorrent/Events/EmptyPeerEvent.hpp
@@ -1,0 +1,37 @@
+#ifndef HADOUKEN_SCRIPTING_MODULES_BITTORRENT_EVENTS_EMPTYPEEREVENT_HPP
+#define HADOUKEN_SCRIPTING_MODULES_BITTORRENT_EVENTS_EMPTYPEEREVENT_HPP
+
+#include <Hadouken/Scripting/Modules/BitTorrent/Events/PeerEvent.hpp>
+
+#include <memory>
+#include <string>
+
+namespace Hadouken
+{
+    namespace BitTorrent
+    {
+        struct TorrentHandle;
+    }
+
+    namespace Scripting
+    {
+        namespace Modules
+        {
+            namespace BitTorrent
+            {
+                namespace Events
+                {
+                    class EmptyPeerEvent : public PeerEvent
+                    {
+                    public:
+                        EmptyPeerEvent(std::shared_ptr<Hadouken::BitTorrent::TorrentHandle> handle, std::string ip, int port);
+
+                        void push(void* ctx);
+                    };
+                }
+            }
+        }
+    }
+}
+
+#endif

--- a/include/Hadouken/Scripting/Modules/BitTorrent/Events/ExternalAddressEvent.hpp
+++ b/include/Hadouken/Scripting/Modules/BitTorrent/Events/ExternalAddressEvent.hpp
@@ -1,0 +1,32 @@
+#ifndef HADOUKEN_SCRIPTING_MODULES_BITTORRENT_EVENTS_EXTERNALADDRESSEVENT_HPP
+#define HADOUKEN_SCRIPTING_MODULES_BITTORRENT_EVENTS_EXTERNALADDRESSEVENT_HPP
+
+#include <Hadouken/Scripting/Event.hpp>
+#include <string>
+
+namespace Hadouken
+{
+    namespace Scripting
+    {
+        namespace Modules
+        {
+            namespace BitTorrent
+            {
+                namespace Events
+                {
+                    class ExternalAddressEvent : public Event
+                    {
+                    public:
+                        ExternalAddressEvent(std::string address);
+                        
+                        void push(void* ctx);
+                    private:
+                        std::string address_;
+                    };
+                }
+            }
+        }
+    }
+}
+
+#endif

--- a/include/Hadouken/Scripting/Modules/BitTorrent/Events/FileCompletedEvent.hpp
+++ b/include/Hadouken/Scripting/Modules/BitTorrent/Events/FileCompletedEvent.hpp
@@ -1,0 +1,38 @@
+#ifndef HADOUKEN_SCRIPTING_MODULES_BITTORRENT_EVENTS_FILECOMPLETEDEVENT_HPP
+#define HADOUKEN_SCRIPTING_MODULES_BITTORRENT_EVENTS_FILECOMPLETEDEVENT_HPP
+
+#include <Hadouken/Scripting/Modules/BitTorrent/Events/TorrentEvent.hpp>
+#include <memory>
+
+namespace Hadouken
+{
+    namespace BitTorrent
+    {
+        struct TorrentHandle;
+    }
+
+    namespace Scripting
+    {
+        namespace Modules
+        {
+            namespace BitTorrent
+            {
+                namespace Events
+                {
+                    class FileCompletedEvent : public TorrentEvent
+                    {
+                    public:
+                        FileCompletedEvent(std::shared_ptr<Hadouken::BitTorrent::TorrentHandle> handle, int index);
+
+                        void push(void* ctx);
+
+                    private:
+                        int index_;
+                    };
+                }
+            }
+        }
+    }
+}
+
+#endif

--- a/include/Hadouken/Scripting/Modules/BitTorrent/Events/FileErrorEvent.hpp
+++ b/include/Hadouken/Scripting/Modules/BitTorrent/Events/FileErrorEvent.hpp
@@ -1,0 +1,42 @@
+#ifndef HADOUKEN_SCRIPTING_MODULES_BITTORRENT_EVENTS_FILEERROREVENT_HPP
+#define HADOUKEN_SCRIPTING_MODULES_BITTORRENT_EVENTS_FILEERROREVENT_HPP
+
+#include <Hadouken/Scripting/Modules/BitTorrent/Events/TorrentEvent.hpp>
+
+#include <Hadouken/BitTorrent/Error.hpp>
+#include <memory>
+#include <string>
+
+namespace Hadouken
+{
+    namespace BitTorrent
+    {
+        struct TorrentHandle;
+    }
+
+    namespace Scripting
+    {
+        namespace Modules
+        {
+            namespace BitTorrent
+            {
+                namespace Events
+                {
+                    class FileErrorEvent : public TorrentEvent
+                    {
+                    public:
+                        FileErrorEvent(std::shared_ptr<Hadouken::BitTorrent::TorrentHandle> handle, Hadouken::BitTorrent::Error error, std::string file);
+
+                        void push(void* ctx);
+
+                    private:
+                        Hadouken::BitTorrent::Error error_;
+                        std::string file_;
+                    };
+                }
+            }
+        }
+    }
+}
+
+#endif

--- a/include/Hadouken/Scripting/Modules/BitTorrent/Events/FileRenameFailedEvent.hpp
+++ b/include/Hadouken/Scripting/Modules/BitTorrent/Events/FileRenameFailedEvent.hpp
@@ -1,0 +1,40 @@
+#ifndef HADOUKEN_SCRIPTING_MODULES_BITTORRENT_EVENTS_FILERENAMEFAILEDEVENT_HPP
+#define HADOUKEN_SCRIPTING_MODULES_BITTORRENT_EVENTS_FILERENAMEFAILEDEVENT_HPP
+
+#include <Hadouken/BitTorrent/Error.hpp>
+#include <Hadouken/Scripting/Modules/BitTorrent/Events/TorrentEvent.hpp>
+#include <memory>
+
+namespace Hadouken
+{
+    namespace BitTorrent
+    {
+        struct TorrentHandle;
+    }
+
+    namespace Scripting
+    {
+        namespace Modules
+        {
+            namespace BitTorrent
+            {
+                namespace Events
+                {
+                    class FileRenameFailedEvent : public TorrentEvent
+                    {
+                    public:
+                        FileRenameFailedEvent(std::shared_ptr<Hadouken::BitTorrent::TorrentHandle> handle, int index, Hadouken::BitTorrent::Error error);
+
+                        void push(void* ctx);
+
+                    private:
+                        Hadouken::BitTorrent::Error error_;
+                        int index_;
+                    };
+                }
+            }
+        }
+    }
+}
+
+#endif

--- a/include/Hadouken/Scripting/Modules/BitTorrent/Events/FileRenamedEvent.hpp
+++ b/include/Hadouken/Scripting/Modules/BitTorrent/Events/FileRenamedEvent.hpp
@@ -1,0 +1,40 @@
+#ifndef HADOUKEN_SCRIPTING_MODULES_BITTORRENT_EVENTS_FILERENAMEDEVENT_HPP
+#define HADOUKEN_SCRIPTING_MODULES_BITTORRENT_EVENTS_FILERENAMEDEVENT_HPP
+
+#include <Hadouken/Scripting/Modules/BitTorrent/Events/TorrentEvent.hpp>
+#include <memory>
+#include <string>
+
+namespace Hadouken
+{
+    namespace BitTorrent
+    {
+        struct TorrentHandle;
+    }
+
+    namespace Scripting
+    {
+        namespace Modules
+        {
+            namespace BitTorrent
+            {
+                namespace Events
+                {
+                    class FileRenamedEvent : public TorrentEvent
+                    {
+                    public:
+                        FileRenamedEvent(std::shared_ptr<Hadouken::BitTorrent::TorrentHandle> handle, int index, std::string name);
+
+                        void push(void* ctx);
+
+                    private:
+                        int index_;
+                        std::string name_;
+                    };
+                }
+            }
+        }
+    }
+}
+
+#endif

--- a/include/Hadouken/Scripting/Modules/BitTorrent/Events/HashFailedEvent.hpp
+++ b/include/Hadouken/Scripting/Modules/BitTorrent/Events/HashFailedEvent.hpp
@@ -1,0 +1,40 @@
+#ifndef HADOUKEN_SCRIPTING_MODULES_BITTORRENT_EVENTS_HASHFAILEDEVENT_HPP
+#define HADOUKEN_SCRIPTING_MODULES_BITTORRENT_EVENTS_HASHFAILEDEVENT_HPP
+
+#include <Hadouken/Scripting/Modules/BitTorrent/Events/TorrentEvent.hpp>
+
+#include <memory>
+#include <string>
+
+namespace Hadouken
+{
+    namespace BitTorrent
+    {
+        struct TorrentHandle;
+    }
+
+    namespace Scripting
+    {
+        namespace Modules
+        {
+            namespace BitTorrent
+            {
+                namespace Events
+                {
+                    class HashFailedEvent : public TorrentEvent
+                    {
+                    public:
+                        HashFailedEvent(std::shared_ptr<Hadouken::BitTorrent::TorrentHandle> handle, int pieceIndex);
+
+                        void push(void* ctx);
+
+                    private:
+                        int pieceIndex_;
+                    };
+                }
+            }
+        }
+    }
+}
+
+#endif

--- a/include/Hadouken/Scripting/Modules/BitTorrent/Events/IncomingConnectionEvent.hpp
+++ b/include/Hadouken/Scripting/Modules/BitTorrent/Events/IncomingConnectionEvent.hpp
@@ -1,0 +1,34 @@
+#ifndef HADOUKEN_SCRIPTING_MODULES_BITTORRENT_EVENTS_INCOMINGCONNECTIONEVENT_HPP
+#define HADOUKEN_SCRIPTING_MODULES_BITTORRENT_EVENTS_INCOMINGCONNECTIONEVENT_HPP
+
+#include <Hadouken/Scripting/Event.hpp>
+#include <string>
+
+namespace Hadouken
+{
+    namespace Scripting
+    {
+        namespace Modules
+        {
+            namespace BitTorrent
+            {
+                namespace Events
+                {
+                    class IncomingConnectionEvent : public Event
+                    {
+                    public:
+                        IncomingConnectionEvent(std::string address, int port);
+
+                        void push(void* ctx);
+
+                    private:
+                        std::string address_;
+                        int port_;
+                    };
+                }
+            }
+        }
+    }
+}
+
+#endif

--- a/include/Hadouken/Scripting/Modules/BitTorrent/Events/ListenSucceededEvent.hpp
+++ b/include/Hadouken/Scripting/Modules/BitTorrent/Events/ListenSucceededEvent.hpp
@@ -1,0 +1,35 @@
+#ifndef HADOUKEN_SCRIPTING_MODULES_BITTORRENT_EVENTS_LISTENSUCCEEDEDEVENT_HPP
+#define HADOUKEN_SCRIPTING_MODULES_BITTORRENT_EVENTS_LISTENSUCCEEDEDEVENT_HPP
+
+#include <Hadouken/Scripting/Event.hpp>
+#include <string>
+
+namespace Hadouken
+{
+    namespace Scripting
+    {
+        namespace Modules
+        {
+            namespace BitTorrent
+            {
+                namespace Events
+                {
+                    class ListenSucceededEvent : public Event
+                    {
+                    public:
+                        ListenSucceededEvent(std::string address, int port, int type);
+
+                        void push(void* ctx);
+
+                    private:
+                        std::string address_;
+                        int port_;
+                        int type_;
+                    };
+                }
+            }
+        }
+    }
+}
+
+#endif

--- a/include/Hadouken/Scripting/Modules/BitTorrent/Events/MetadataFailedEvent.hpp
+++ b/include/Hadouken/Scripting/Modules/BitTorrent/Events/MetadataFailedEvent.hpp
@@ -1,0 +1,41 @@
+#ifndef HADOUKEN_SCRIPTING_MODULES_BITTORRENT_EVENTS_METADATAFAILEDEVENT_HPP
+#define HADOUKEN_SCRIPTING_MODULES_BITTORRENT_EVENTS_METADATAFAILEDEVENT_HPP
+
+#include <Hadouken/Scripting/Modules/BitTorrent/Events/TorrentEvent.hpp>
+
+#include <Hadouken/BitTorrent/Error.hpp>
+#include <memory>
+#include <string>
+
+namespace Hadouken
+{
+    namespace BitTorrent
+    {
+        struct TorrentHandle;
+    }
+
+    namespace Scripting
+    {
+        namespace Modules
+        {
+            namespace BitTorrent
+            {
+                namespace Events
+                {
+                    class MetadataFailedEvent : public TorrentEvent
+                    {
+                    public:
+                        MetadataFailedEvent(std::shared_ptr<Hadouken::BitTorrent::TorrentHandle> handle, Hadouken::BitTorrent::Error error);
+
+                        void push(void* ctx);
+
+                    private:
+                        Hadouken::BitTorrent::Error error_;
+                    };
+                }
+            }
+        }
+    }
+}
+
+#endif

--- a/include/Hadouken/Scripting/Modules/BitTorrent/Events/PeerErrorEvent.hpp
+++ b/include/Hadouken/Scripting/Modules/BitTorrent/Events/PeerErrorEvent.hpp
@@ -1,0 +1,40 @@
+#ifndef HADOUKEN_SCRIPTING_MODULES_BITTORRENT_EVENTS_PEERERROREVENT_HPP
+#define HADOUKEN_SCRIPTING_MODULES_BITTORRENT_EVENTS_PEERERROREVENT_HPP
+
+#include <Hadouken/Scripting/Modules/BitTorrent/Events/PeerEvent.hpp>
+
+#include <Hadouken/BitTorrent/Error.hpp>
+#include <memory>
+
+namespace Hadouken
+{
+    namespace BitTorrent
+    {
+        struct TorrentHandle;
+    }
+
+    namespace Scripting
+    {
+        namespace Modules
+        {
+            namespace BitTorrent
+            {
+                namespace Events
+                {
+                    class PeerErrorEvent : public PeerEvent
+                    {
+                    public:
+                        PeerErrorEvent(std::shared_ptr<Hadouken::BitTorrent::TorrentHandle> handle, std::string ip, int port, Hadouken::BitTorrent::Error error);
+
+                        void push(void* ctx);
+
+                    private:
+                        Hadouken::BitTorrent::Error error_;
+                    };
+                }
+            }
+        }
+    }
+}
+
+#endif

--- a/include/Hadouken/Scripting/Modules/BitTorrent/Events/PeerEvent.hpp
+++ b/include/Hadouken/Scripting/Modules/BitTorrent/Events/PeerEvent.hpp
@@ -1,0 +1,41 @@
+#ifndef HADOUKEN_SCRIPTING_MODULES_BITTORRENT_EVENTS_PEEREVENT_HPP
+#define HADOUKEN_SCRIPTING_MODULES_BITTORRENT_EVENTS_PEEREVENT_HPP
+
+#include <Hadouken/Scripting/Modules/BitTorrent/Events/TorrentEvent.hpp>
+
+#include <memory>
+#include <string>
+
+namespace Hadouken
+{
+    namespace BitTorrent
+    {
+        struct TorrentHandle;
+    }
+
+    namespace Scripting
+    {
+        namespace Modules
+        {
+            namespace BitTorrent
+            {
+                namespace Events
+                {
+                    class PeerEvent : public TorrentEvent
+                    {
+                    public:
+                        PeerEvent(std::shared_ptr<Hadouken::BitTorrent::TorrentHandle> handle, std::string ip, int port);
+
+                        void push(void* ctx, int idx);
+
+                    private:
+                        std::string ip_;
+                        int port_;
+                    };
+                }
+            }
+        }
+    }
+}
+
+#endif

--- a/include/Hadouken/Scripting/Modules/BitTorrent/Events/PerformanceEvent.hpp
+++ b/include/Hadouken/Scripting/Modules/BitTorrent/Events/PerformanceEvent.hpp
@@ -1,0 +1,39 @@
+#ifndef HADOUKEN_SCRIPTING_MODULES_BITTORRENT_EVENTS_PERFORMANCEEVENT_HPP
+#define HADOUKEN_SCRIPTING_MODULES_BITTORRENT_EVENTS_PERFORMANCEEVENT_HPP
+
+#include <Hadouken/Scripting/Modules/BitTorrent/Events/TorrentEvent.hpp>
+#include <memory>
+#include <string>
+
+namespace Hadouken
+{
+    namespace BitTorrent
+    {
+        struct TorrentHandle;
+    }
+
+    namespace Scripting
+    {
+        namespace Modules
+        {
+            namespace BitTorrent
+            {
+                namespace Events
+                {
+                    class PerformanceEvent : public TorrentEvent
+                    {
+                    public:
+                        PerformanceEvent(std::shared_ptr<Hadouken::BitTorrent::TorrentHandle> handle, int code);
+
+                        void push(void* ctx);
+
+                    private:
+                        int code_;
+                    };
+                }
+            }
+        }
+    }
+}
+
+#endif

--- a/include/Hadouken/Scripting/Modules/BitTorrent/Events/PieceFinishedEvent.hpp
+++ b/include/Hadouken/Scripting/Modules/BitTorrent/Events/PieceFinishedEvent.hpp
@@ -1,0 +1,40 @@
+#ifndef HADOUKEN_SCRIPTING_MODULES_BITTORRENT_EVENTS_PIECEFINISHEDEVENT_HPP
+#define HADOUKEN_SCRIPTING_MODULES_BITTORRENT_EVENTS_PIECEFINISHEDEVENT_HPP
+
+#include <Hadouken/Scripting/Modules/BitTorrent/Events/TorrentEvent.hpp>
+
+#include <memory>
+#include <string>
+
+namespace Hadouken
+{
+    namespace BitTorrent
+    {
+        struct TorrentHandle;
+    }
+
+    namespace Scripting
+    {
+        namespace Modules
+        {
+            namespace BitTorrent
+            {
+                namespace Events
+                {
+                    class PieceFinishedEvent : public TorrentEvent
+                    {
+                    public:
+                        PieceFinishedEvent(std::shared_ptr<Hadouken::BitTorrent::TorrentHandle> handle, int pieceIndex);
+
+                        void push(void* ctx);
+
+                    private:
+                        int pieceIndex_;
+                    };
+                }
+            }
+        }
+    }
+}
+
+#endif

--- a/include/Hadouken/Scripting/Modules/BitTorrent/Events/ScrapeFailedEvent.hpp
+++ b/include/Hadouken/Scripting/Modules/BitTorrent/Events/ScrapeFailedEvent.hpp
@@ -1,0 +1,40 @@
+#ifndef HADOUKEN_SCRIPTING_MODULES_BITTORRENT_EVENTS_SCRAPEFAILEDEVENT_HPP
+#define HADOUKEN_SCRIPTING_MODULES_BITTORRENT_EVENTS_SCRAPEFAILEDEVENT_HPP
+
+#include <Hadouken/Scripting/Modules/BitTorrent/Events/TrackerEvent.hpp>
+
+#include <memory>
+#include <string>
+
+namespace Hadouken
+{
+    namespace BitTorrent
+    {
+        struct TorrentHandle;
+    }
+
+    namespace Scripting
+    {
+        namespace Modules
+        {
+            namespace BitTorrent
+            {
+                namespace Events
+                {
+                    class ScrapeFailedEvent : public TrackerEvent
+                    {
+                    public:
+                        ScrapeFailedEvent(std::shared_ptr<Hadouken::BitTorrent::TorrentHandle> handle, std::string url, std::string message);
+
+                        void push(void* ctx);
+
+                    private:
+                        std::string message_;
+                    };
+                }
+            }
+        }
+    }
+}
+
+#endif

--- a/include/Hadouken/Scripting/Modules/BitTorrent/Events/ScrapeReplyEvent.hpp
+++ b/include/Hadouken/Scripting/Modules/BitTorrent/Events/ScrapeReplyEvent.hpp
@@ -1,0 +1,41 @@
+#ifndef HADOUKEN_SCRIPTING_MODULES_BITTORRENT_EVENTS_SCRAPEREPLYEVENT_HPP
+#define HADOUKEN_SCRIPTING_MODULES_BITTORRENT_EVENTS_SCRAPEREPLYEVENT_HPP
+
+#include <Hadouken/Scripting/Modules/BitTorrent/Events/TrackerEvent.hpp>
+
+#include <memory>
+#include <string>
+
+namespace Hadouken
+{
+    namespace BitTorrent
+    {
+        struct TorrentHandle;
+    }
+
+    namespace Scripting
+    {
+        namespace Modules
+        {
+            namespace BitTorrent
+            {
+                namespace Events
+                {
+                    class ScrapeReplyEvent : public TrackerEvent
+                    {
+                    public:
+                        ScrapeReplyEvent(std::shared_ptr<Hadouken::BitTorrent::TorrentHandle> handle, std::string url, int complete, int incomplete);
+
+                        void push(void* ctx);
+
+                    private:
+                        int complete_;
+                        int incomplete_;
+                    };
+                }
+            }
+        }
+    }
+}
+
+#endif

--- a/include/Hadouken/Scripting/Modules/BitTorrent/Events/StateChangedEvent.hpp
+++ b/include/Hadouken/Scripting/Modules/BitTorrent/Events/StateChangedEvent.hpp
@@ -1,0 +1,40 @@
+#ifndef HADOUKEN_SCRIPTING_MODULES_BITTORRENT_EVENTS_STATECHANGEDEVENT_HPP
+#define HADOUKEN_SCRIPTING_MODULES_BITTORRENT_EVENTS_STATECHANGEDEVENT_HPP
+
+#include <Hadouken/Scripting/Modules/BitTorrent/Events/TorrentEvent.hpp>
+#include <memory>
+#include <string>
+
+namespace Hadouken
+{
+    namespace BitTorrent
+    {
+        struct TorrentHandle;
+    }
+
+    namespace Scripting
+    {
+        namespace Modules
+        {
+            namespace BitTorrent
+            {
+                namespace Events
+                {
+                    class StateChangedEvent : public TorrentEvent
+                    {
+                    public:
+                        StateChangedEvent(std::shared_ptr<Hadouken::BitTorrent::TorrentHandle> handle, int state, int previousState);
+
+                        void push(void* ctx);
+
+                    private:
+                        int state_;
+                        int previousState_;
+                    };
+                }
+            }
+        }
+    }
+}
+
+#endif

--- a/include/Hadouken/Scripting/Modules/BitTorrent/Events/StorageMoveFailedEvent.hpp
+++ b/include/Hadouken/Scripting/Modules/BitTorrent/Events/StorageMoveFailedEvent.hpp
@@ -1,0 +1,39 @@
+#ifndef HADOUKEN_SCRIPTING_MODULES_BITTORRENT_EVENTS_STORAGEMOVEFAILEDEVENT_HPP
+#define HADOUKEN_SCRIPTING_MODULES_BITTORRENT_EVENTS_STORAGEMOVEFAILEDEVENT_HPP
+
+#include <Hadouken/BitTorrent/Error.hpp>
+#include <Hadouken/Scripting/Modules/BitTorrent/Events/TorrentEvent.hpp>
+#include <memory>
+
+namespace Hadouken
+{
+    namespace BitTorrent
+    {
+        struct TorrentHandle;
+    }
+
+    namespace Scripting
+    {
+        namespace Modules
+        {
+            namespace BitTorrent
+            {
+                namespace Events
+                {
+                    class StorageMoveFailedEvent : public TorrentEvent
+                    {
+                    public:
+                        StorageMoveFailedEvent(std::shared_ptr<Hadouken::BitTorrent::TorrentHandle> handle, Hadouken::BitTorrent::Error error);
+
+                        void push(void* ctx);
+
+                    private:
+                        Hadouken::BitTorrent::Error error_;
+                    };
+                }
+            }
+        }
+    }
+}
+
+#endif

--- a/include/Hadouken/Scripting/Modules/BitTorrent/Events/StorageMovedEvent.hpp
+++ b/include/Hadouken/Scripting/Modules/BitTorrent/Events/StorageMovedEvent.hpp
@@ -1,0 +1,39 @@
+#ifndef HADOUKEN_SCRIPTING_MODULES_BITTORRENT_EVENTS_STORAGEMOVEDEVENT_HPP
+#define HADOUKEN_SCRIPTING_MODULES_BITTORRENT_EVENTS_STORAGEMOVEDEVENT_HPP
+
+#include <Hadouken/Scripting/Modules/BitTorrent/Events/TorrentEvent.hpp>
+#include <memory>
+#include <string>
+
+namespace Hadouken
+{
+    namespace BitTorrent
+    {
+        struct TorrentHandle;
+    }
+
+    namespace Scripting
+    {
+        namespace Modules
+        {
+            namespace BitTorrent
+            {
+                namespace Events
+                {
+                    class StorageMovedEvent : public TorrentEvent
+                    {
+                    public:
+                        StorageMovedEvent(std::shared_ptr<Hadouken::BitTorrent::TorrentHandle> handle, std::string path);
+
+                        void push(void* ctx);
+
+                    private:
+                        std::string path_;
+                    };
+                }
+            }
+        }
+    }
+}
+
+#endif

--- a/include/Hadouken/Scripting/Modules/BitTorrent/Events/TorrentDeleteFailedEvent.hpp
+++ b/include/Hadouken/Scripting/Modules/BitTorrent/Events/TorrentDeleteFailedEvent.hpp
@@ -1,0 +1,36 @@
+#ifndef HADOUKEN_SCRIPTING_MODULES_BITTORRENT_EVENTS_TORRENTDELETEFAILEDEVENT_HPP
+#define HADOUKEN_SCRIPTING_MODULES_BITTORRENT_EVENTS_TORRENTDELETEFAILEDEVENT_HPP
+
+#include <Hadouken/Scripting/Event.hpp>
+
+#include <Hadouken/BitTorrent/Error.hpp>
+#include <string>
+
+namespace Hadouken
+{
+    namespace Scripting
+    {
+        namespace Modules
+        {
+            namespace BitTorrent
+            {
+                namespace Events
+                {
+                    class TorrentDeleteFailedEvent : public Event
+                    {
+                    public:
+                        TorrentDeleteFailedEvent(std::string infoHash, Hadouken::BitTorrent::Error error);
+
+                        void push(void* ctx);
+
+                    private:
+                        std::string infoHash_;
+                        Hadouken::BitTorrent::Error error_;
+                    };
+                }
+            }
+        }
+    }
+}
+
+#endif

--- a/include/Hadouken/Scripting/Modules/BitTorrent/Events/TorrentDeletedEvent.hpp
+++ b/include/Hadouken/Scripting/Modules/BitTorrent/Events/TorrentDeletedEvent.hpp
@@ -1,0 +1,33 @@
+#ifndef HADOUKEN_SCRIPTING_MODULES_BITTORRENT_EVENTS_TORRENTDELETEDEVENT_HPP
+#define HADOUKEN_SCRIPTING_MODULES_BITTORRENT_EVENTS_TORRENTDELETEDEVENT_HPP
+
+#include <Hadouken/Scripting/Event.hpp>
+#include <string>
+
+namespace Hadouken
+{
+    namespace Scripting
+    {
+        namespace Modules
+        {
+            namespace BitTorrent
+            {
+                namespace Events
+                {
+                    class TorrentDeletedEvent : public Event
+                    {
+                    public:
+                        TorrentDeletedEvent(std::string infoHash);
+
+                        void push(void* ctx);
+
+                    private:
+                        std::string infoHash_;
+                    };
+                }
+            }
+        }
+    }
+}
+
+#endif

--- a/include/Hadouken/Scripting/Modules/BitTorrent/Events/TorrentErrorEvent.hpp
+++ b/include/Hadouken/Scripting/Modules/BitTorrent/Events/TorrentErrorEvent.hpp
@@ -1,0 +1,40 @@
+#ifndef HADOUKEN_SCRIPTING_MODULES_BITTORRENT_EVENTS_TORRENTERROREVENT_HPP
+#define HADOUKEN_SCRIPTING_MODULES_BITTORRENT_EVENTS_TORRENTERROREVENT_HPP
+
+#include <Hadouken/BitTorrent/Error.hpp>
+#include <Hadouken/Scripting/Modules/BitTorrent/Events/TorrentEvent.hpp>
+#include <memory>
+
+namespace Hadouken
+{
+    namespace BitTorrent
+    {
+        struct TorrentHandle;
+    }
+
+    namespace Scripting
+    {
+        namespace Modules
+        {
+            namespace BitTorrent
+            {
+                namespace Events
+                {
+                    class TorrentErrorEvent : public TorrentEvent
+                    {
+                    public:
+                        TorrentErrorEvent(std::shared_ptr<Hadouken::BitTorrent::TorrentHandle> handle, Hadouken::BitTorrent::Error error);
+
+                        void push(void* ctx);
+
+                    private:
+                        std::shared_ptr<Hadouken::BitTorrent::TorrentHandle> handle_;
+                        Hadouken::BitTorrent::Error error_;
+                    };
+                }
+            }
+        }
+    }
+}
+
+#endif

--- a/include/Hadouken/Scripting/Modules/BitTorrent/Events/TrackerAnnounceEvent.hpp
+++ b/include/Hadouken/Scripting/Modules/BitTorrent/Events/TrackerAnnounceEvent.hpp
@@ -1,0 +1,40 @@
+#ifndef HADOUKEN_SCRIPTING_MODULES_BITTORRENT_EVENTS_TRACKERANNOUNCEEVENT_HPP
+#define HADOUKEN_SCRIPTING_MODULES_BITTORRENT_EVENTS_TRACKERANNOUNCEEVENT_HPP
+
+#include <Hadouken/Scripting/Modules/BitTorrent/Events/TrackerEvent.hpp>
+
+#include <memory>
+#include <string>
+
+namespace Hadouken
+{
+    namespace BitTorrent
+    {
+        struct TorrentHandle;
+    }
+
+    namespace Scripting
+    {
+        namespace Modules
+        {
+            namespace BitTorrent
+            {
+                namespace Events
+                {
+                    class TrackerAnnounceEvent : public TrackerEvent
+                    {
+                    public:
+                        TrackerAnnounceEvent(std::shared_ptr<Hadouken::BitTorrent::TorrentHandle> handle, std::string url, int event);
+
+                        void push(void* ctx);
+
+                    private:
+                        int event_;
+                    };
+                }
+            }
+        }
+    }
+}
+
+#endif

--- a/include/Hadouken/Scripting/Modules/BitTorrent/Events/TrackerErrorEvent.hpp
+++ b/include/Hadouken/Scripting/Modules/BitTorrent/Events/TrackerErrorEvent.hpp
@@ -1,0 +1,44 @@
+#ifndef HADOUKEN_SCRIPTING_MODULES_BITTORRENT_EVENTS_TRACKERERROREVENT_HPP
+#define HADOUKEN_SCRIPTING_MODULES_BITTORRENT_EVENTS_TRACKERERROREVENT_HPP
+
+#include <Hadouken/Scripting/Modules/BitTorrent/Events/TrackerEvent.hpp>
+
+#include <Hadouken/BitTorrent/Error.hpp>
+#include <memory>
+#include <string>
+
+namespace Hadouken
+{
+    namespace BitTorrent
+    {
+        struct TorrentHandle;
+    }
+
+    namespace Scripting
+    {
+        namespace Modules
+        {
+            namespace BitTorrent
+            {
+                namespace Events
+                {
+                    class TrackerErrorEvent : public TrackerEvent
+                    {
+                    public:
+                        TrackerErrorEvent(std::shared_ptr<Hadouken::BitTorrent::TorrentHandle> handle, Hadouken::BitTorrent::Error error, std::string url, int times, int statusCode, std::string message);
+
+                        void push(void* ctx);
+
+                    private:
+                        Hadouken::BitTorrent::Error error_;
+                        int times_;
+                        int statusCode_;
+                        std::string message_;
+                    };
+                }
+            }
+        }
+    }
+}
+
+#endif

--- a/include/Hadouken/Scripting/Modules/BitTorrent/Events/TrackerEvent.hpp
+++ b/include/Hadouken/Scripting/Modules/BitTorrent/Events/TrackerEvent.hpp
@@ -1,0 +1,39 @@
+#ifndef HADOUKEN_SCRIPTING_MODULES_BITTORRENT_EVENTS_TRACKEREVENT_HPP
+#define HADOUKEN_SCRIPTING_MODULES_BITTORRENT_EVENTS_TRACKEREVENT_HPP
+
+#include <Hadouken/Scripting/Modules/BitTorrent/Events/TorrentEvent.hpp>
+#include <memory>
+#include <string>
+
+namespace Hadouken
+{
+    namespace BitTorrent
+    {
+        struct TorrentHandle;
+    }
+
+    namespace Scripting
+    {
+        namespace Modules
+        {
+            namespace BitTorrent
+            {
+                namespace Events
+                {
+                    class TrackerEvent : public TorrentEvent
+                    {
+                    public:
+                        TrackerEvent(std::shared_ptr<Hadouken::BitTorrent::TorrentHandle> handle, std::string url);
+
+                        void push(void* ctx, int idx);
+
+                    private:
+                        std::string url_;
+                    };
+                }
+            }
+        }
+    }
+}
+
+#endif

--- a/include/Hadouken/Scripting/Modules/BitTorrent/Events/TrackerIdEvent.hpp
+++ b/include/Hadouken/Scripting/Modules/BitTorrent/Events/TrackerIdEvent.hpp
@@ -1,0 +1,40 @@
+#ifndef HADOUKEN_SCRIPTING_MODULES_BITTORRENT_EVENTS_TRACKERIDEVENT_HPP
+#define HADOUKEN_SCRIPTING_MODULES_BITTORRENT_EVENTS_TRACKERIDEVENT_HPP
+
+#include <Hadouken/Scripting/Modules/BitTorrent/Events/TrackerEvent.hpp>
+
+#include <memory>
+#include <string>
+
+namespace Hadouken
+{
+    namespace BitTorrent
+    {
+        struct TorrentHandle;
+    }
+
+    namespace Scripting
+    {
+        namespace Modules
+        {
+            namespace BitTorrent
+            {
+                namespace Events
+                {
+                    class TrackerIdEvent : public TrackerEvent
+                    {
+                    public:
+                        TrackerIdEvent(std::shared_ptr<Hadouken::BitTorrent::TorrentHandle> handle, std::string url, std::string trackerId);
+
+                        void push(void* ctx);
+
+                    private:
+                        std::string trackerId_;
+                    };
+                }
+            }
+        }
+    }
+}
+
+#endif

--- a/include/Hadouken/Scripting/Modules/BitTorrent/Events/TrackerReplyEvent.hpp
+++ b/include/Hadouken/Scripting/Modules/BitTorrent/Events/TrackerReplyEvent.hpp
@@ -1,0 +1,40 @@
+#ifndef HADOUKEN_SCRIPTING_MODULES_BITTORRENT_EVENTS_TRACKERREPLYEVENT_HPP
+#define HADOUKEN_SCRIPTING_MODULES_BITTORRENT_EVENTS_TRACKERREPLYEVENT_HPP
+
+#include <Hadouken/Scripting/Modules/BitTorrent/Events/TrackerEvent.hpp>
+
+#include <memory>
+#include <string>
+
+namespace Hadouken
+{
+    namespace BitTorrent
+    {
+        struct TorrentHandle;
+    }
+
+    namespace Scripting
+    {
+        namespace Modules
+        {
+            namespace BitTorrent
+            {
+                namespace Events
+                {
+                    class TrackerReplyEvent : public TrackerEvent
+                    {
+                    public:
+                        TrackerReplyEvent(std::shared_ptr<Hadouken::BitTorrent::TorrentHandle> handle, std::string url, int numPeers);
+
+                        void push(void* ctx);
+
+                    private:
+                        int numPeers_;
+                    };
+                }
+            }
+        }
+    }
+}
+
+#endif

--- a/include/Hadouken/Scripting/Modules/BitTorrent/Events/TrackerWarningEvent.hpp
+++ b/include/Hadouken/Scripting/Modules/BitTorrent/Events/TrackerWarningEvent.hpp
@@ -1,0 +1,40 @@
+#ifndef HADOUKEN_SCRIPTING_MODULES_BITTORRENT_EVENTS_TRACKERWARNINGEVENT_HPP
+#define HADOUKEN_SCRIPTING_MODULES_BITTORRENT_EVENTS_TRACKERWARNINGEVENT_HPP
+
+#include <Hadouken/Scripting/Modules/BitTorrent/Events/TrackerEvent.hpp>
+
+#include <memory>
+#include <string>
+
+namespace Hadouken
+{
+    namespace BitTorrent
+    {
+        struct TorrentHandle;
+    }
+
+    namespace Scripting
+    {
+        namespace Modules
+        {
+            namespace BitTorrent
+            {
+                namespace Events
+                {
+                    class TrackerWarningEvent : public TrackerEvent
+                    {
+                    public:
+                        TrackerWarningEvent(std::shared_ptr<Hadouken::BitTorrent::TorrentHandle> handle, std::string url, std::string message);
+
+                        void push(void* ctx);
+
+                    private:
+                        std::string message_;
+                    };
+                }
+            }
+        }
+    }
+}
+
+#endif

--- a/include/Hadouken/Scripting/Modules/BitTorrent/Events/UrlSeedEvent.hpp
+++ b/include/Hadouken/Scripting/Modules/BitTorrent/Events/UrlSeedEvent.hpp
@@ -1,0 +1,41 @@
+#ifndef HADOUKEN_SCRIPTING_MODULES_BITTORRENT_EVENTS_URLSEEDEVENT_HPP
+#define HADOUKEN_SCRIPTING_MODULES_BITTORRENT_EVENTS_URLSEEDEVENT_HPP
+
+#include <Hadouken/Scripting/Modules/BitTorrent/Events/TorrentEvent.hpp>
+
+#include <memory>
+#include <string>
+
+namespace Hadouken
+{
+    namespace BitTorrent
+    {
+        struct TorrentHandle;
+    }
+
+    namespace Scripting
+    {
+        namespace Modules
+        {
+            namespace BitTorrent
+            {
+                namespace Events
+                {
+                    class UrlSeedEvent : public TorrentEvent
+                    {
+                    public:
+                        UrlSeedEvent(std::shared_ptr<Hadouken::BitTorrent::TorrentHandle> handle, std::string url, std::string message);
+
+                        void push(void* ctx);
+
+                    private:
+                        std::string url_;
+                        std::string message_;
+                    };
+                }
+            }
+        }
+    }
+}
+
+#endif

--- a/include/Hadouken/Scripting/Modules/BitTorrent/TorrentHandleWrapper.hpp
+++ b/include/Hadouken/Scripting/Modules/BitTorrent/TorrentHandleWrapper.hpp
@@ -25,6 +25,9 @@ namespace Hadouken
                     static void initialize(void* ctx, std::shared_ptr<Hadouken::BitTorrent::TorrentHandle> handle);
 
                 private:
+                    static int finalize(void* ctx);
+                    static int finalizeMetadata(void* ctx);
+
                     static int clearError(void* ctx);
                     static int forceRecheck(void* ctx);
                     static int getInfoHash(void* ctx);
@@ -33,6 +36,8 @@ namespace Hadouken
                     static int getStatus(void* ctx);
                     static int getTorrentInfo(void* ctx);
                     static int getTrackers(void* ctx);
+                    static int isValid(void* ctx);
+                    static int metadata(void* ctx);
                     static int moveStorage(void* ctx);
                     static int pause(void* ctx);
                     static int renameFile(void* ctx);
@@ -42,10 +47,6 @@ namespace Hadouken
                     static int queueDown(void* ctx);
                     static int queueTop(void* ctx);
                     static int queueUp(void* ctx);
-
-                    static int getMetadata(void* ctx);
-                    static int getMetadataKeys(void* ctx);
-                    static int setMetadata(void* ctx);
 
                     static int getMaxConnections(void* ctx);
                     static int getMaxUploads(void* ctx);

--- a/js/core.js
+++ b/js/core.js
@@ -1,0 +1,63 @@
+var logger = require("logger").get("core");
+
+var eventTranslator = {
+    // libtorrent alert name       hadouken name
+    "block_downloading_alert":     "peer.blockDownloading",
+    "block_finished_alert":        "peer.blockFinished",
+    "block_timeout_alert":         "peer.blockTimeout",
+    "cache_flushed_alert":         "torrent.cacheFlushed",
+    "dht_bootstrap_alert":         "dht.bootstrap",
+    "dht_reply_alert":             "dht.reply",
+    "external_ip_alert":           "externalAddress",
+    "file_completed_alert":        "file.completed",
+    "file_error_alert":            "file.error",
+    "file_renamed_alert":          "file.renamed",
+    "file_rename_failed_alert":    "file.renameFailed",
+    "hash_failed_alert":           "torrent.hashFailed",
+    "incoming_connection_alert":   "incomingConnection",
+    "lsd_peer_alert":              "peer.lsd",
+    "metadata_failed_alert":       "torrent.metadataFailed",
+    "metadata_received_alert":     "torrent.metadataReceived",
+    "peer_ban_alert":              "peer.ban",
+    "peer_connect_alert":          "peer.connect",
+    "peer_disconnected_alert":     "peer.disconnected",
+    "peer_error_alert":            "peer.error",
+    "peer_snubbed_alert":          "peer.snubbed",
+    "peer_unsnubbed_alert":        "peer.unsnubbed",
+    "performance_alert":           "torrent.performanceWarning",
+    "piece_finished_alert":        "piece.finished",
+    "request_dropped_alert":       "peer.requestDropped",
+    "scrape_reply_alert":          "tracker.scrapeReply",
+    "scrape_failed_alert":         "tracker.scrapeFailed",
+    "state_changed_alert":         "torrent.stateChanged",
+    "stats_alert":                 "torrent.stats",
+    "storage_moved_alert":         "torrent.moved",
+    "storage_moved_failed_alert":  "torrent.moveFailed",
+    "tick":                        "tick",
+    "torrent_added_alert":         "torrent.added",
+    "torrent_checked_alert":       "torrent.checked",
+    "torrent_deleted_alert":       "torrent.deleted",
+    "torrent_delete_failed_alert": "torrent.deleteFailed",
+    "torrent_error_alert":         "torrent.error",
+    "torrent_finished_alert":      "torrent.finished",
+    "torrent_need_cert_alert":     "torrent.needCertificate",
+    "torrent_paused_alert":        "torrent.paused",
+    "torrent_resumed_alert":       "torrent.resumed",
+    "torrent_removed_alert":       "torrent.removed",
+    "trackerid_alert":             "tracker.id",
+    "tracker_announce_alert":      "tracker.announce",
+    "tracker_error_alert":         "tracker.error",
+    "tracker_reply_alert":         "tracker.reply",
+    "tracker_warning_alert":       "tracker.warning",
+    "unwanted_block_alert":        "peer.unwantedBlock",
+    "url_seed_alert":              "torrent.urlSeed"
+};
+
+exports.getEventName = function(alertName) {
+    if(eventTranslator[alertName]) {
+        return eventTranslator[alertName];
+    }
+
+    logger.warn("Alert not translated: " + alertName);
+    return alertName;
+};

--- a/js/events.js
+++ b/js/events.js
@@ -1,3 +1,4 @@
+var core      = require("core");
 var logger    = require("logger").get("events");
 var callbacks = {};
 
@@ -11,6 +12,7 @@ exports.register = function(eventName, callback) {
 }
 
 exports.emitter = function(eventName, eventData) {
+    eventName = core.getEventName(eventName);
     var list = callbacks[eventName];
 
     if(!list) {

--- a/js/rpc/torrent_getMetadata.js
+++ b/js/rpc/torrent_getMetadata.js
@@ -2,20 +2,21 @@ var session = require("bittorrent").session;
 
 exports.rpc = {
     name: "torrent.getMetadata",
-    method: function(infoHash) {
+    method: function(infoHash, key) {
         var torrent = session.findTorrent(infoHash);
 
-        if(!torrent) {
+        if(!torrent || !torrent.isValid) {
             return null;
         }
 
-        var data = {};
-        var keys = torrent.metadata.keys;
+        if(key) {
+            var val = torrent.metadata(key);
 
-        for(var i = 0; i < keys.length; i++) {
-            data[keys[i]] = torrent.metadata.get(keys[i]);
+            if(typeof val === 'undefined') {
+                throw new Error("Key not found: " + key);
+            }
         }
 
-        return data;
+        return torrent.metadata();
     }
 };

--- a/js/rpc/torrent_setMetadata.js
+++ b/js/rpc/torrent_setMetadata.js
@@ -5,11 +5,11 @@ exports.rpc = {
     method: function(infoHash, key, value) {
         var torrent = session.findTorrent(infoHash);
 
-        if(!torrent) {
-            return false;
+        if(!torrent || !torrent.isValid) {
+            throw Error("Invalid info hash: " + infoHash);
         }
 
-        torrent.metadata.set(key, value);
+        torrent.metadata(key, value);
         return true;
     }
 };

--- a/src/bittorrent/torrenthandle.cpp
+++ b/src/bittorrent/torrenthandle.cpp
@@ -15,9 +15,8 @@ TorrentHandle::TorrentHandle(const libtorrent::torrent_handle& handle)
 {
 }
 
-TorrentHandle::TorrentHandle(const TorrentHandle& h)
-    : handle_(h.handle_),
-      data_(h.data_)
+TorrentHandle::TorrentHandle(const TorrentHandle& handle)
+    : handle_(handle.handle_)
 {
 }
 
@@ -197,39 +196,4 @@ void TorrentHandle::setUploadLimit(int limit) const
 void TorrentHandle::setUploadMode(bool mode) const
 {
     handle_.set_upload_mode(mode);
-}
-
-std::vector<std::string> TorrentHandle::getDataKeys()
-{
-    std::vector<std::string> result;
-
-    for (std::pair<std::string, std::string> p : data_)
-    {
-        result.push_back(p.first);
-    }
-
-    return result;
-}
-
-std::string TorrentHandle::getData(std::string key)
-{
-    if (data_.find(key) == data_.end())
-    {
-        return std::string();
-    }
-
-    return data_.at(key);
-}
-
-void TorrentHandle::setData(std::string key, std::string value)
-{
-    data_[key] = value;
-}
-
-void TorrentHandle::clearData(std::string key)
-{
-    if (data_.find(key) != data_.end())
-    {
-        data_.erase(key);
-    }
 }

--- a/src/scripting/modules/bittorrent/events/blockevent.cpp
+++ b/src/scripting/modules/bittorrent/events/blockevent.cpp
@@ -1,0 +1,27 @@
+#include <Hadouken/Scripting/Modules/BitTorrent/Events/BlockEvent.hpp>
+
+#include <Hadouken/BitTorrent/TorrentHandle.hpp>
+
+#include "../../../duktape.h"
+
+using namespace Hadouken::BitTorrent;
+using namespace Hadouken::Scripting::Modules::BitTorrent::Events;
+
+BlockEvent::BlockEvent(std::shared_ptr<TorrentHandle> handle, std::string ip, int port, int pieceIndex, int blockIndex)
+    : PeerEvent(handle, ip, port)
+{
+    pieceIndex_ = pieceIndex;
+    blockIndex_ = blockIndex;
+}
+
+void BlockEvent::push(duk_context* ctx)
+{
+    duk_idx_t idx = duk_push_object(ctx);
+    PeerEvent::push(ctx, idx);
+
+    duk_push_int(ctx, pieceIndex_);
+    duk_put_prop_string(ctx, idx, "pieceIndex");
+
+    duk_push_int(ctx, blockIndex_);
+    duk_put_prop_string(ctx, idx, "blockIndex");
+}

--- a/src/scripting/modules/bittorrent/events/dhtreplyevent.cpp
+++ b/src/scripting/modules/bittorrent/events/dhtreplyevent.cpp
@@ -1,0 +1,22 @@
+#include <Hadouken/Scripting/Modules/BitTorrent/Events/DhtReplyEvent.hpp>
+
+#include <Hadouken/BitTorrent/TorrentHandle.hpp>
+#include "../../../duktape.h"
+
+using namespace Hadouken::BitTorrent;
+using namespace Hadouken::Scripting::Modules::BitTorrent::Events;
+
+DhtReplyEvent::DhtReplyEvent(std::shared_ptr<TorrentHandle> handle, std::string url, int numPeers)
+    : TrackerEvent(handle, url)
+{
+    numPeers_ = numPeers;
+}
+
+void DhtReplyEvent::push(duk_context* ctx)
+{
+    duk_idx_t idx = duk_push_object(ctx);
+    TrackerEvent::push(ctx, idx);
+    
+    duk_push_int(ctx, numPeers_);
+    duk_put_prop_string(ctx, idx, "numPeers");
+}

--- a/src/scripting/modules/bittorrent/events/emptyevent.cpp
+++ b/src/scripting/modules/bittorrent/events/emptyevent.cpp
@@ -1,0 +1,10 @@
+#include <Hadouken/Scripting/Modules/BitTorrent/Events/EmptyEvent.hpp>
+
+#include "../../../duktape.h"
+
+using namespace Hadouken::Scripting::Modules::BitTorrent::Events;
+
+void EmptyEvent::push(duk_context* ctx)
+{
+    duk_push_undefined(ctx);
+}

--- a/src/scripting/modules/bittorrent/events/emptypeerevent.cpp
+++ b/src/scripting/modules/bittorrent/events/emptypeerevent.cpp
@@ -1,0 +1,19 @@
+#include <Hadouken/Scripting/Modules/BitTorrent/Events/EmptyPeerEvent.hpp>
+
+#include <Hadouken/BitTorrent/TorrentHandle.hpp>
+
+#include "../../../duktape.h"
+
+using namespace Hadouken::BitTorrent;
+using namespace Hadouken::Scripting::Modules::BitTorrent::Events;
+
+EmptyPeerEvent::EmptyPeerEvent(std::shared_ptr<TorrentHandle> handle, std::string ip, int port)
+    : PeerEvent(handle, ip, port)
+{
+}
+
+void EmptyPeerEvent::push(duk_context* ctx)
+{
+    duk_idx_t idx = duk_push_object(ctx);
+    PeerEvent::push(ctx, idx);
+}

--- a/src/scripting/modules/bittorrent/events/externaladdressevent.cpp
+++ b/src/scripting/modules/bittorrent/events/externaladdressevent.cpp
@@ -1,0 +1,15 @@
+#include <Hadouken/Scripting/Modules/BitTorrent/Events/ExternalAddressEvent.hpp>
+
+#include "../../../duktape.h"
+
+using namespace Hadouken::Scripting::Modules::BitTorrent::Events;
+
+ExternalAddressEvent::ExternalAddressEvent(std::string address)
+    : address_(address)
+{
+}
+
+void ExternalAddressEvent::push(duk_context* ctx)
+{
+    duk_push_string(ctx, address_.c_str());
+}

--- a/src/scripting/modules/bittorrent/events/filecompletedevent.cpp
+++ b/src/scripting/modules/bittorrent/events/filecompletedevent.cpp
@@ -1,0 +1,24 @@
+#include <Hadouken/Scripting/Modules/BitTorrent/Events/FileCompletedEvent.hpp>
+
+#include <Hadouken/BitTorrent/TorrentHandle.hpp>
+#include "../../../duktape.h"
+
+using namespace Hadouken::BitTorrent;
+using namespace Hadouken::Scripting::Modules::BitTorrent::Events;
+
+FileCompletedEvent::FileCompletedEvent(std::shared_ptr<TorrentHandle> handle, int index)
+    : TorrentEvent(handle)
+{
+    index_ = index;
+}
+
+void FileCompletedEvent::push(duk_context* ctx)
+{
+    duk_idx_t idx = duk_push_object(ctx);
+    
+    TorrentEvent::push(ctx);
+    duk_put_prop_string(ctx, idx, "torrent");
+
+    duk_push_int(ctx, index_);
+    duk_put_prop_string(ctx, idx, "index");
+}

--- a/src/scripting/modules/bittorrent/events/fileerrorevent.cpp
+++ b/src/scripting/modules/bittorrent/events/fileerrorevent.cpp
@@ -1,0 +1,36 @@
+#include <Hadouken/Scripting/Modules/BitTorrent/Events/FileErrorEvent.hpp>
+
+#include <Hadouken/BitTorrent/TorrentHandle.hpp>
+#include "../../../duktape.h"
+
+using namespace Hadouken::BitTorrent;
+using namespace Hadouken::Scripting::Modules::BitTorrent::Events;
+
+FileErrorEvent::FileErrorEvent(std::shared_ptr<TorrentHandle> handle, Error error, std::string file)
+    : TorrentEvent(handle),
+    error_(error),
+    file_(file)
+{
+}
+
+void FileErrorEvent::push(duk_context* ctx)
+{
+    duk_idx_t idx = duk_push_object(ctx);
+    
+    TorrentEvent::push(ctx);
+    duk_put_prop_string(ctx, idx, "torrent");
+
+    duk_push_string(ctx, file_.c_str());
+    duk_put_prop_string(ctx, idx, "file");
+
+    // ---- error
+    duk_idx_t errIdx = duk_push_object(ctx);
+    
+    duk_push_int(ctx, error_.code);
+    duk_put_prop_string(ctx, errIdx, "code");
+
+    duk_push_string(ctx, error_.message.c_str());
+    duk_put_prop_string(ctx, errIdx, "message");
+
+    duk_put_prop_string(ctx, idx, "error");
+}

--- a/src/scripting/modules/bittorrent/events/filerenamedevent.cpp
+++ b/src/scripting/modules/bittorrent/events/filerenamedevent.cpp
@@ -1,0 +1,28 @@
+#include <Hadouken/Scripting/Modules/BitTorrent/Events/FileRenamedEvent.hpp>
+
+#include <Hadouken/BitTorrent/TorrentHandle.hpp>
+#include "../../../duktape.h"
+
+using namespace Hadouken::BitTorrent;
+using namespace Hadouken::Scripting::Modules::BitTorrent::Events;
+
+FileRenamedEvent::FileRenamedEvent(std::shared_ptr<TorrentHandle> handle, int index, std::string name)
+    : TorrentEvent(handle)
+{
+    index_ = index;
+    name_ = name;
+}
+
+void FileRenamedEvent::push(duk_context* ctx)
+{
+    duk_idx_t idx = duk_push_object(ctx);
+    
+    TorrentEvent::push(ctx);
+    duk_put_prop_string(ctx, idx, "torrent");
+
+    duk_push_int(ctx, index_);
+    duk_put_prop_string(ctx, idx, "index");
+
+    duk_push_string(ctx, name_.c_str());
+    duk_put_prop_string(ctx, idx, "name");
+}

--- a/src/scripting/modules/bittorrent/events/filerenamefailedevent.cpp
+++ b/src/scripting/modules/bittorrent/events/filerenamefailedevent.cpp
@@ -1,0 +1,36 @@
+#include <Hadouken/Scripting/Modules/BitTorrent/Events/FileRenameFailedEvent.hpp>
+
+#include <Hadouken/BitTorrent/TorrentHandle.hpp>
+#include "../../../duktape.h"
+
+using namespace Hadouken::BitTorrent;
+using namespace Hadouken::Scripting::Modules::BitTorrent::Events;
+
+FileRenameFailedEvent::FileRenameFailedEvent(std::shared_ptr<TorrentHandle> handle, int index, Error error)
+    : error_(error),
+    TorrentEvent(handle)
+{
+    index_ = index;
+}
+
+void FileRenameFailedEvent::push(duk_context* ctx)
+{
+    duk_idx_t idx = duk_push_object(ctx);
+    
+    TorrentEvent::push(ctx);
+    duk_put_prop_string(ctx, idx, "torrent");
+
+    duk_push_int(ctx, index_);
+    duk_put_prop_string(ctx, idx, "index");
+
+    // ---- error
+    duk_idx_t errIdx = duk_push_object(ctx);
+    
+    duk_push_int(ctx, error_.code);
+    duk_put_prop_string(ctx, errIdx, "code");
+
+    duk_push_string(ctx, error_.message.c_str());
+    duk_put_prop_string(ctx, errIdx, "message");
+
+    duk_put_prop_string(ctx, idx, "error");
+}

--- a/src/scripting/modules/bittorrent/events/hashfailedevent.cpp
+++ b/src/scripting/modules/bittorrent/events/hashfailedevent.cpp
@@ -1,0 +1,24 @@
+#include <Hadouken/Scripting/Modules/BitTorrent/Events/HashFailedEvent.hpp>
+
+#include <Hadouken/BitTorrent/TorrentHandle.hpp>
+#include "../../../duktape.h"
+
+using namespace Hadouken::BitTorrent;
+using namespace Hadouken::Scripting::Modules::BitTorrent::Events;
+
+HashFailedEvent::HashFailedEvent(std::shared_ptr<TorrentHandle> handle, int pieceIndex)
+    : TorrentEvent(handle)
+{
+    pieceIndex_ = pieceIndex;
+}
+
+void HashFailedEvent::push(duk_context* ctx)
+{
+    duk_idx_t idx = duk_push_object(ctx);
+    
+    TorrentEvent::push(ctx);
+    duk_put_prop_string(ctx, idx, "torrent");
+
+    duk_push_int(ctx, pieceIndex_);
+    duk_put_prop_string(ctx, idx, "pieceIndex");
+}

--- a/src/scripting/modules/bittorrent/events/incomingconnectionevent.cpp
+++ b/src/scripting/modules/bittorrent/events/incomingconnectionevent.cpp
@@ -1,0 +1,25 @@
+#include <Hadouken/Scripting/Modules/BitTorrent/Events/IncomingConnectionEvent.hpp>
+
+#include "../../../duktape.h"
+
+using namespace Hadouken::Scripting::Modules::BitTorrent::Events;
+
+IncomingConnectionEvent::IncomingConnectionEvent(std::string address, int port)
+    : address_(address)
+{
+    port_ = port;
+}
+
+void IncomingConnectionEvent::push(duk_context* ctx)
+{
+    duk_idx_t idx = duk_push_object(ctx);
+    duk_idx_t ipIdx = duk_push_object(ctx);
+
+    duk_push_string(ctx, address_.c_str());
+    duk_put_prop_string(ctx, ipIdx, "address");
+
+    duk_push_int(ctx, port_);
+    duk_put_prop_string(ctx, ipIdx, "port");
+
+    duk_put_prop_string(ctx, idx, "ip");
+}

--- a/src/scripting/modules/bittorrent/events/listensucceededevent.cpp
+++ b/src/scripting/modules/bittorrent/events/listensucceededevent.cpp
@@ -1,0 +1,29 @@
+#include <Hadouken/Scripting/Modules/BitTorrent/Events/ListenSucceededEvent.hpp>
+
+#include "../../../duktape.h"
+
+using namespace Hadouken::Scripting::Modules::BitTorrent::Events;
+
+ListenSucceededEvent::ListenSucceededEvent(std::string address, int port, int type)
+    : address_(address)
+{
+    port_ = port;
+    type_ = type;
+}
+
+void ListenSucceededEvent::push(duk_context* ctx)
+{
+    duk_idx_t idx = duk_push_object(ctx);
+    duk_idx_t ipIdx = duk_push_object(ctx);
+
+    duk_push_string(ctx, address_.c_str());
+    duk_put_prop_string(ctx, ipIdx, "address");
+
+    duk_push_int(ctx, port_);
+    duk_put_prop_string(ctx, ipIdx, "port");
+
+    duk_put_prop_string(ctx, idx, "ip");
+
+    duk_push_int(ctx, type_);
+    duk_put_prop_string(ctx, idx, "type");
+}

--- a/src/scripting/modules/bittorrent/events/metadatafailedevent.cpp
+++ b/src/scripting/modules/bittorrent/events/metadatafailedevent.cpp
@@ -1,0 +1,32 @@
+#include <Hadouken/Scripting/Modules/BitTorrent/Events/MetadataFailedEvent.hpp>
+
+#include <Hadouken/BitTorrent/TorrentHandle.hpp>
+#include "../../../duktape.h"
+
+using namespace Hadouken::BitTorrent;
+using namespace Hadouken::Scripting::Modules::BitTorrent::Events;
+
+MetadataFailedEvent::MetadataFailedEvent(std::shared_ptr<TorrentHandle> handle, Error error)
+    : TorrentEvent(handle),
+    error_(error)
+{
+}
+
+void MetadataFailedEvent::push(duk_context* ctx)
+{
+    duk_idx_t idx = duk_push_object(ctx);
+    
+    TorrentEvent::push(ctx);
+    duk_put_prop_string(ctx, idx, "torrent");
+
+    // ---- error
+    duk_idx_t errIdx = duk_push_object(ctx);
+    
+    duk_push_int(ctx, error_.code);
+    duk_put_prop_string(ctx, errIdx, "code");
+
+    duk_push_string(ctx, error_.message.c_str());
+    duk_put_prop_string(ctx, errIdx, "message");
+
+    duk_put_prop_string(ctx, idx, "error");
+}

--- a/src/scripting/modules/bittorrent/events/peererrorevent.cpp
+++ b/src/scripting/modules/bittorrent/events/peererrorevent.cpp
@@ -1,0 +1,25 @@
+#include <Hadouken/Scripting/Modules/BitTorrent/Events/PeerErrorEvent.hpp>
+
+#include <Hadouken/BitTorrent/TorrentHandle.hpp>
+
+#include "../../../duktape.h"
+
+using namespace Hadouken::BitTorrent;
+using namespace Hadouken::Scripting::Modules::BitTorrent::Events;
+
+PeerErrorEvent::PeerErrorEvent(std::shared_ptr<TorrentHandle> handle, std::string ip, int port, Error error)
+    : PeerEvent(handle, ip, port),
+    error_(error)
+{
+}
+
+void PeerErrorEvent::push(duk_context* ctx)
+{
+    duk_idx_t idx = duk_push_object(ctx);
+    PeerEvent::push(ctx, idx);
+
+    // ----- error
+    duk_idx_t errIdx = duk_push_object(ctx);
+
+    duk_put_prop_string(ctx, idx, "error");
+}

--- a/src/scripting/modules/bittorrent/events/peerevent.cpp
+++ b/src/scripting/modules/bittorrent/events/peerevent.cpp
@@ -1,0 +1,31 @@
+#include <Hadouken/Scripting/Modules/BitTorrent/Events/PeerEvent.hpp>
+
+#include <Hadouken/BitTorrent/TorrentHandle.hpp>
+
+#include "../../../duktape.h"
+
+using namespace Hadouken::BitTorrent;
+using namespace Hadouken::Scripting::Modules::BitTorrent::Events;
+
+PeerEvent::PeerEvent(std::shared_ptr<TorrentHandle> handle, std::string ip, int port)
+    : TorrentEvent(handle),
+    ip_(ip)
+{
+    port_ = port;
+}
+
+void PeerEvent::push(duk_context* ctx, duk_idx_t idx)
+{
+    TorrentEvent::push(ctx);
+    duk_put_prop_string(ctx, idx, "torrent");
+
+    duk_idx_t ipIdx = duk_push_object(ctx);
+
+    duk_push_string(ctx, ip_.c_str());
+    duk_put_prop_string(ctx, ipIdx, "address");
+
+    duk_push_int(ctx, port_);
+    duk_put_prop_string(ctx, ipIdx, "port");
+
+    duk_put_prop_string(ctx, idx, "ip");
+}

--- a/src/scripting/modules/bittorrent/events/performanceevent.cpp
+++ b/src/scripting/modules/bittorrent/events/performanceevent.cpp
@@ -1,0 +1,24 @@
+#include <Hadouken/Scripting/Modules/BitTorrent/Events/PerformanceEvent.hpp>
+
+#include <Hadouken/BitTorrent/TorrentHandle.hpp>
+#include "../../../duktape.h"
+
+using namespace Hadouken::BitTorrent;
+using namespace Hadouken::Scripting::Modules::BitTorrent::Events;
+
+PerformanceEvent::PerformanceEvent(std::shared_ptr<TorrentHandle> handle, int code)
+    : TorrentEvent(handle)
+{
+    code_ = code;
+}
+
+void PerformanceEvent::push(duk_context* ctx)
+{
+    duk_idx_t idx = duk_push_object(ctx);
+    
+    TorrentEvent::push(ctx);
+    duk_put_prop_string(ctx, idx, "torrent");
+
+    duk_push_int(ctx, code_);
+    duk_put_prop_string(ctx, idx, "code");
+}

--- a/src/scripting/modules/bittorrent/events/piecefinishedevent.cpp
+++ b/src/scripting/modules/bittorrent/events/piecefinishedevent.cpp
@@ -1,0 +1,24 @@
+#include <Hadouken/Scripting/Modules/BitTorrent/Events/PieceFinishedEvent.hpp>
+
+#include <Hadouken/BitTorrent/TorrentHandle.hpp>
+#include "../../../duktape.h"
+
+using namespace Hadouken::BitTorrent;
+using namespace Hadouken::Scripting::Modules::BitTorrent::Events;
+
+PieceFinishedEvent::PieceFinishedEvent(std::shared_ptr<TorrentHandle> handle, int pieceIndex)
+    : TorrentEvent(handle)
+{
+    pieceIndex_ = pieceIndex;
+}
+
+void PieceFinishedEvent::push(duk_context* ctx)
+{
+    duk_idx_t idx = duk_push_object(ctx);
+    
+    TorrentEvent::push(ctx);
+    duk_put_prop_string(ctx, idx, "torrent");
+
+    duk_push_int(ctx, pieceIndex_);
+    duk_put_prop_string(ctx, idx, "pieceIndex");
+}

--- a/src/scripting/modules/bittorrent/events/scrapefailedevent.cpp
+++ b/src/scripting/modules/bittorrent/events/scrapefailedevent.cpp
@@ -1,0 +1,22 @@
+#include <Hadouken/Scripting/Modules/BitTorrent/Events/ScrapeFailedEvent.hpp>
+
+#include <Hadouken/BitTorrent/TorrentHandle.hpp>
+#include "../../../duktape.h"
+
+using namespace Hadouken::BitTorrent;
+using namespace Hadouken::Scripting::Modules::BitTorrent::Events;
+
+ScrapeFailedEvent::ScrapeFailedEvent(std::shared_ptr<TorrentHandle> handle, std::string url, std::string message)
+    : TrackerEvent(handle, url),
+    message_(message)
+{
+}
+
+void ScrapeFailedEvent::push(duk_context* ctx)
+{
+    duk_idx_t idx = duk_push_object(ctx);
+    TrackerEvent::push(ctx, idx);
+    
+    duk_push_string(ctx, message_.c_str());
+    duk_put_prop_string(ctx, idx, "message");
+}

--- a/src/scripting/modules/bittorrent/events/scrapereplyevent.cpp
+++ b/src/scripting/modules/bittorrent/events/scrapereplyevent.cpp
@@ -1,0 +1,26 @@
+#include <Hadouken/Scripting/Modules/BitTorrent/Events/ScrapeReplyEvent.hpp>
+
+#include <Hadouken/BitTorrent/TorrentHandle.hpp>
+#include "../../../duktape.h"
+
+using namespace Hadouken::BitTorrent;
+using namespace Hadouken::Scripting::Modules::BitTorrent::Events;
+
+ScrapeReplyEvent::ScrapeReplyEvent(std::shared_ptr<TorrentHandle> handle, std::string url, int complete, int incomplete)
+    : TrackerEvent(handle, url)
+{
+    complete_ = complete;
+    incomplete_ = incomplete;
+}
+
+void ScrapeReplyEvent::push(duk_context* ctx)
+{
+    duk_idx_t idx = duk_push_object(ctx);
+    TrackerEvent::push(ctx, idx);
+    
+    duk_push_int(ctx, complete_);
+    duk_put_prop_string(ctx, idx, "complete");
+
+    duk_push_int(ctx, incomplete_);
+    duk_put_prop_string(ctx, idx, "incomplete");
+}

--- a/src/scripting/modules/bittorrent/events/statechangedevent.cpp
+++ b/src/scripting/modules/bittorrent/events/statechangedevent.cpp
@@ -1,0 +1,28 @@
+#include <Hadouken/Scripting/Modules/BitTorrent/Events/StateChangedEvent.hpp>
+
+#include <Hadouken/BitTorrent/TorrentHandle.hpp>
+#include "../../../duktape.h"
+
+using namespace Hadouken::BitTorrent;
+using namespace Hadouken::Scripting::Modules::BitTorrent::Events;
+
+StateChangedEvent::StateChangedEvent(std::shared_ptr<TorrentHandle> handle, int state, int previousState)
+    : TorrentEvent(handle)
+{
+    state_ = state;
+    previousState_ = previousState;
+}
+
+void StateChangedEvent::push(duk_context* ctx)
+{
+    duk_idx_t idx = duk_push_object(ctx);
+    
+    TorrentEvent::push(ctx);
+    duk_put_prop_string(ctx, idx, "torrent");
+
+    duk_push_int(ctx, state_);
+    duk_put_prop_string(ctx, idx, "state");
+
+    duk_push_int(ctx, previousState_);
+    duk_put_prop_string(ctx, idx, "previousState");
+}

--- a/src/scripting/modules/bittorrent/events/storagemovedevent.cpp
+++ b/src/scripting/modules/bittorrent/events/storagemovedevent.cpp
@@ -1,0 +1,24 @@
+#include <Hadouken/Scripting/Modules/BitTorrent/Events/StorageMovedEvent.hpp>
+
+#include <Hadouken/BitTorrent/TorrentHandle.hpp>
+#include "../../../duktape.h"
+
+using namespace Hadouken::BitTorrent;
+using namespace Hadouken::Scripting::Modules::BitTorrent::Events;
+
+StorageMovedEvent::StorageMovedEvent(std::shared_ptr<TorrentHandle> handle, std::string path)
+    : TorrentEvent(handle)
+{
+    path_ = path;
+}
+
+void StorageMovedEvent::push(duk_context* ctx)
+{
+    duk_idx_t idx = duk_push_object(ctx);
+    
+    TorrentEvent::push(ctx);
+    duk_put_prop_string(ctx, idx, "torrent");
+
+    duk_push_string(ctx, path_.c_str());
+    duk_put_prop_string(ctx, idx, "path");
+}

--- a/src/scripting/modules/bittorrent/events/storagemovefailedevent.cpp
+++ b/src/scripting/modules/bittorrent/events/storagemovefailedevent.cpp
@@ -1,0 +1,32 @@
+#include <Hadouken/Scripting/Modules/BitTorrent/Events/StorageMoveFailedEvent.hpp>
+
+#include <Hadouken/BitTorrent/TorrentHandle.hpp>
+#include "../../../duktape.h"
+
+using namespace Hadouken::BitTorrent;
+using namespace Hadouken::Scripting::Modules::BitTorrent::Events;
+
+StorageMoveFailedEvent::StorageMoveFailedEvent(std::shared_ptr<TorrentHandle> handle, Error error)
+    : error_(error),
+    TorrentEvent(handle)
+{
+}
+
+void StorageMoveFailedEvent::push(duk_context* ctx)
+{
+    duk_idx_t idx = duk_push_object(ctx);
+    
+    TorrentEvent::push(ctx);
+    duk_put_prop_string(ctx, idx, "torrent");
+
+    // ---- error
+    duk_idx_t errIdx = duk_push_object(ctx);
+    
+    duk_push_int(ctx, error_.code);
+    duk_put_prop_string(ctx, errIdx, "code");
+
+    duk_push_string(ctx, error_.message.c_str());
+    duk_put_prop_string(ctx, errIdx, "message");
+
+    duk_put_prop_string(ctx, idx, "error");
+}

--- a/src/scripting/modules/bittorrent/events/torrentdeletedevent.cpp
+++ b/src/scripting/modules/bittorrent/events/torrentdeletedevent.cpp
@@ -1,0 +1,15 @@
+#include <Hadouken/Scripting/Modules/BitTorrent/Events/TorrentDeletedEvent.hpp>
+
+#include "../../../duktape.h"
+
+using namespace Hadouken::Scripting::Modules::BitTorrent::Events;
+
+TorrentDeletedEvent::TorrentDeletedEvent(std::string infoHash)
+    : infoHash_(infoHash)
+{
+}
+
+void TorrentDeletedEvent::push(duk_context* ctx)
+{
+    duk_push_string(ctx, infoHash_.c_str());
+}

--- a/src/scripting/modules/bittorrent/events/torrentdeletefailedevent.cpp
+++ b/src/scripting/modules/bittorrent/events/torrentdeletefailedevent.cpp
@@ -1,0 +1,31 @@
+#include <Hadouken/Scripting/Modules/BitTorrent/Events/TorrentDeleteFailedEvent.hpp>
+
+#include "../../../duktape.h"
+
+using namespace Hadouken::BitTorrent;
+using namespace Hadouken::Scripting::Modules::BitTorrent::Events;
+
+TorrentDeleteFailedEvent::TorrentDeleteFailedEvent(std::string infoHash, Error error)
+    : infoHash_(infoHash),
+    error_(error)
+{
+}
+
+void TorrentDeleteFailedEvent::push(duk_context* ctx)
+{
+    duk_idx_t idx = duk_push_object(ctx);
+
+    duk_push_string(ctx, infoHash_.c_str());
+    duk_put_prop_string(ctx, idx, "infoHash");
+
+    // ---- error
+    duk_idx_t errIdx = duk_push_object(ctx);
+    
+    duk_push_int(ctx, error_.code);
+    duk_put_prop_string(ctx, errIdx, "code");
+
+    duk_push_string(ctx, error_.message.c_str());
+    duk_put_prop_string(ctx, errIdx, "message");
+
+    duk_put_prop_string(ctx, idx, "error");
+}

--- a/src/scripting/modules/bittorrent/events/torrenterrorevent.cpp
+++ b/src/scripting/modules/bittorrent/events/torrenterrorevent.cpp
@@ -1,0 +1,32 @@
+#include <Hadouken/Scripting/Modules/BitTorrent/Events/TorrentErrorEvent.hpp>
+
+#include <Hadouken/BitTorrent/TorrentHandle.hpp>
+#include "../../../duktape.h"
+
+using namespace Hadouken::BitTorrent;
+using namespace Hadouken::Scripting::Modules::BitTorrent::Events;
+
+TorrentErrorEvent::TorrentErrorEvent(std::shared_ptr<TorrentHandle> handle, Error err)
+    : TorrentEvent(handle),
+    error_(err)
+{
+}
+
+void TorrentErrorEvent::push(duk_context* ctx)
+{
+    duk_idx_t idx = duk_push_object(ctx);
+    
+    TorrentEvent::push(ctx);
+    duk_put_prop_string(ctx, idx, "torrent");
+
+    // ---- error
+    duk_idx_t errIdx = duk_push_object(ctx);
+    
+    duk_push_int(ctx, error_.code);
+    duk_put_prop_string(ctx, errIdx, "code");
+
+    duk_push_string(ctx, error_.message.c_str());
+    duk_put_prop_string(ctx, errIdx, "message");
+
+    duk_put_prop_string(ctx, idx, "error");
+}

--- a/src/scripting/modules/bittorrent/events/trackerannounceevent.cpp
+++ b/src/scripting/modules/bittorrent/events/trackerannounceevent.cpp
@@ -1,0 +1,22 @@
+#include <Hadouken/Scripting/Modules/BitTorrent/Events/TrackerAnnounceEvent.hpp>
+
+#include <Hadouken/BitTorrent/TorrentHandle.hpp>
+#include "../../../duktape.h"
+
+using namespace Hadouken::BitTorrent;
+using namespace Hadouken::Scripting::Modules::BitTorrent::Events;
+
+TrackerAnnounceEvent::TrackerAnnounceEvent(std::shared_ptr<TorrentHandle> handle, std::string url, int event)
+    : TrackerEvent(handle, url)
+{
+    event_ = event;
+}
+
+void TrackerAnnounceEvent::push(duk_context* ctx)
+{
+    duk_idx_t idx = duk_push_object(ctx);
+    TrackerEvent::push(ctx, idx);
+    
+    duk_push_int(ctx, event_);
+    duk_put_prop_string(ctx, idx, "event");
+}

--- a/src/scripting/modules/bittorrent/events/trackererrorevent.cpp
+++ b/src/scripting/modules/bittorrent/events/trackererrorevent.cpp
@@ -1,0 +1,42 @@
+#include <Hadouken/Scripting/Modules/BitTorrent/Events/TrackerErrorEvent.hpp>
+
+#include <Hadouken/BitTorrent/TorrentHandle.hpp>
+#include "../../../duktape.h"
+
+using namespace Hadouken::BitTorrent;
+using namespace Hadouken::Scripting::Modules::BitTorrent::Events;
+
+TrackerErrorEvent::TrackerErrorEvent(std::shared_ptr<TorrentHandle> handle, Error error, std::string url, int times, int statusCode, std::string message)
+    : TrackerEvent(handle, url),
+    error_(error),
+    message_(message)
+{
+    times_ = times;
+    statusCode_ = statusCode;
+}
+
+void TrackerErrorEvent::push(duk_context* ctx)
+{
+    duk_idx_t idx = duk_push_object(ctx);
+    TrackerEvent::push(ctx, idx);
+
+    duk_push_int(ctx, times_);
+    duk_put_prop_string(ctx, idx, "times");
+
+    duk_push_int(ctx, statusCode_);
+    duk_put_prop_string(ctx, idx, "statusCode");
+
+    duk_push_string(ctx, message_.c_str());
+    duk_put_prop_string(ctx, idx, "message");
+
+    // ---- error
+    duk_idx_t errIdx = duk_push_object(ctx);
+    
+    duk_push_int(ctx, error_.code);
+    duk_put_prop_string(ctx, errIdx, "code");
+
+    duk_push_string(ctx, error_.message.c_str());
+    duk_put_prop_string(ctx, errIdx, "message");
+
+    duk_put_prop_string(ctx, idx, "error");
+}

--- a/src/scripting/modules/bittorrent/events/trackerevent.cpp
+++ b/src/scripting/modules/bittorrent/events/trackerevent.cpp
@@ -1,0 +1,23 @@
+#include <Hadouken/Scripting/Modules/BitTorrent/Events/TrackerEvent.hpp>
+
+#include <Hadouken/BitTorrent/TorrentHandle.hpp>
+
+#include "../../../duktape.h"
+
+using namespace Hadouken::BitTorrent;
+using namespace Hadouken::Scripting::Modules::BitTorrent::Events;
+
+TrackerEvent::TrackerEvent(std::shared_ptr<TorrentHandle> handle, std::string url)
+    : TorrentEvent(handle),
+    url_(url)
+{
+}
+
+void TrackerEvent::push(duk_context* ctx, duk_idx_t idx)
+{
+    TorrentEvent::push(ctx);
+    duk_put_prop_string(ctx, idx, "torrent");
+
+    duk_push_string(ctx, url_.c_str());
+    duk_put_prop_string(ctx, idx, "url");
+}

--- a/src/scripting/modules/bittorrent/events/trackeridevent.cpp
+++ b/src/scripting/modules/bittorrent/events/trackeridevent.cpp
@@ -1,0 +1,22 @@
+#include <Hadouken/Scripting/Modules/BitTorrent/Events/TrackerIdEvent.hpp>
+
+#include <Hadouken/BitTorrent/TorrentHandle.hpp>
+#include "../../../duktape.h"
+
+using namespace Hadouken::BitTorrent;
+using namespace Hadouken::Scripting::Modules::BitTorrent::Events;
+
+TrackerIdEvent::TrackerIdEvent(std::shared_ptr<TorrentHandle> handle, std::string url, std::string trackerId)
+    : TrackerEvent(handle, url),
+    trackerId_(trackerId)
+{
+}
+
+void TrackerIdEvent::push(duk_context* ctx)
+{
+    duk_idx_t idx = duk_push_object(ctx);
+    TrackerEvent::push(ctx, idx);
+    
+    duk_push_string(ctx, trackerId_.c_str());
+    duk_put_prop_string(ctx, idx, "id");
+}

--- a/src/scripting/modules/bittorrent/events/trackerreplyevent.cpp
+++ b/src/scripting/modules/bittorrent/events/trackerreplyevent.cpp
@@ -1,0 +1,22 @@
+#include <Hadouken/Scripting/Modules/BitTorrent/Events/TrackerReplyEvent.hpp>
+
+#include <Hadouken/BitTorrent/TorrentHandle.hpp>
+#include "../../../duktape.h"
+
+using namespace Hadouken::BitTorrent;
+using namespace Hadouken::Scripting::Modules::BitTorrent::Events;
+
+TrackerReplyEvent::TrackerReplyEvent(std::shared_ptr<TorrentHandle> handle, std::string url, int numPeers)
+    : TrackerEvent(handle, url)
+{
+    numPeers_ = numPeers;
+}
+
+void TrackerReplyEvent::push(duk_context* ctx)
+{
+    duk_idx_t idx = duk_push_object(ctx);
+    TrackerEvent::push(ctx, idx);
+    
+    duk_push_int(ctx, numPeers_);
+    duk_put_prop_string(ctx, idx, "numPeers");
+}

--- a/src/scripting/modules/bittorrent/events/trackerwarningevent.cpp
+++ b/src/scripting/modules/bittorrent/events/trackerwarningevent.cpp
@@ -1,0 +1,22 @@
+#include <Hadouken/Scripting/Modules/BitTorrent/Events/TrackerWarningEvent.hpp>
+
+#include <Hadouken/BitTorrent/TorrentHandle.hpp>
+#include "../../../duktape.h"
+
+using namespace Hadouken::BitTorrent;
+using namespace Hadouken::Scripting::Modules::BitTorrent::Events;
+
+TrackerWarningEvent::TrackerWarningEvent(std::shared_ptr<TorrentHandle> handle, std::string url, std::string message)
+    : TrackerEvent(handle, url),
+    message_(message)
+{
+}
+
+void TrackerWarningEvent::push(duk_context* ctx)
+{
+    duk_idx_t idx = duk_push_object(ctx);
+    TrackerEvent::push(ctx, idx);
+    
+    duk_push_string(ctx, message_.c_str());
+    duk_put_prop_string(ctx, idx, "message");
+}

--- a/src/scripting/modules/bittorrent/events/urlseedevent.cpp
+++ b/src/scripting/modules/bittorrent/events/urlseedevent.cpp
@@ -1,0 +1,28 @@
+#include <Hadouken/Scripting/Modules/BitTorrent/Events/UrlSeedEvent.hpp>
+
+#include <Hadouken/BitTorrent/TorrentHandle.hpp>
+#include "../../../duktape.h"
+
+using namespace Hadouken::BitTorrent;
+using namespace Hadouken::Scripting::Modules::BitTorrent::Events;
+
+UrlSeedEvent::UrlSeedEvent(std::shared_ptr<TorrentHandle> handle, std::string url, std::string message)
+    : TorrentEvent(handle),
+    url_(url),
+    message_(message)
+{
+}
+
+void UrlSeedEvent::push(duk_context* ctx)
+{
+    duk_idx_t idx = duk_push_object(ctx);
+    
+    TorrentEvent::push(ctx);
+    duk_put_prop_string(ctx, idx, "torrent");
+
+    duk_push_string(ctx, url_.c_str());
+    duk_put_prop_string(ctx, idx, "url");
+
+    duk_push_string(ctx, message_.c_str());
+    duk_put_prop_string(ctx, idx, "message");
+}

--- a/src/scripting/modules/bittorrent/torrenthandlewrapper.cpp
+++ b/src/scripting/modules/bittorrent/torrenthandlewrapper.cpp
@@ -2,13 +2,16 @@
 
 #include <Hadouken/BitTorrent/AnnounceEntry.hpp>
 #include <Hadouken/BitTorrent/PeerInfo.hpp>
+#include <Hadouken/BitTorrent/Session.hpp>
 #include <Hadouken/BitTorrent/TorrentInfo.hpp>
 #include <Hadouken/BitTorrent/TorrentHandle.hpp>
 #include <Hadouken/BitTorrent/TorrentStatus.hpp>
+#include <Hadouken/BitTorrent/TorrentSubsystem.hpp>
 #include <Hadouken/Scripting/Modules/BitTorrent/AnnounceEntryWrapper.hpp>
 #include <Hadouken/Scripting/Modules/BitTorrent/PeerInfoWrapper.hpp>
 #include <Hadouken/Scripting/Modules/BitTorrent/TorrentInfoWrapper.hpp>
 #include <Hadouken/Scripting/Modules/BitTorrent/TorrentStatusWrapper.hpp>
+#include <Poco/Util/Application.h>
 
 #include "../common.hpp"
 #include "../../duktape.h"
@@ -27,6 +30,7 @@ void TorrentHandleWrapper::initialize(duk_context* ctx, std::shared_ptr<Hadouken
         { "getStatus",      getStatus,      0 },
         { "getTorrentInfo", getTorrentInfo, 0 },
         { "getTrackers",    getTrackers,    0 },
+        { "metadata",       metadata,       DUK_VARARGS },
         { "moveStorage",    moveStorage,    1 },
         { "pause",          pause,          0 },
         { "queueBottom",    queueBottom,    0 },
@@ -41,11 +45,15 @@ void TorrentHandleWrapper::initialize(duk_context* ctx, std::shared_ptr<Hadouken
     duk_idx_t idx = duk_push_object(ctx);
     duk_put_function_list(ctx, idx, functions);
 
-    Common::setPointer<TorrentHandle>(ctx, idx, handle.get());
+    Common::setPointer<TorrentHandle>(ctx, idx, new TorrentHandle(*handle));
 
     // read-only properties
     DUK_READONLY_PROPERTY(ctx, idx, infoHash, getInfoHash);
+    DUK_READONLY_PROPERTY(ctx, idx, isValid, isValid);
     DUK_READONLY_PROPERTY(ctx, idx, queuePosition, getQueuePosition);
+
+    duk_push_c_function(ctx, finalize, 1);
+    duk_set_finalizer(ctx, -2);
 
     // read+write properties
     DUK_READWRITE_PROPERTY(ctx, idx, maxConnections, getMaxConnections, setMaxConnections);
@@ -54,23 +62,18 @@ void TorrentHandleWrapper::initialize(duk_context* ctx, std::shared_ptr<Hadouken
     DUK_READWRITE_PROPERTY(ctx, idx, sequentialDownload, getSequentialDownload, setSequentialDownload);
     DUK_READWRITE_PROPERTY(ctx, idx, uploadMode, getUploadMode, setUploadMode);
     DUK_READWRITE_PROPERTY(ctx, idx, uploadLimit, getUploadLimit, setUploadLimit);
+}
 
-    // ----------------- metadata
-    duk_function_list_entry metaFunctions[] =
-    {
-        { "get", getMetadata, 1 },
-        { "set", setMetadata, 2 },
-        { NULL,  NULL,        0}
-    };
-    
-    duk_idx_t metaIdx = duk_push_object(ctx);
-    duk_put_function_list(ctx, metaIdx, metaFunctions);
+duk_ret_t TorrentHandleWrapper::finalize(duk_context* ctx)
+{
+    Common::finalize<TorrentHandle>(ctx);
+    return 0;
+}
 
-    Common::setPointer<TorrentHandle>(ctx, metaIdx, handle.get());
-
-    DUK_READONLY_PROPERTY(ctx, metaIdx, keys, getMetadataKeys);
-
-    duk_put_prop_string(ctx, idx, "metadata");
+duk_ret_t TorrentHandleWrapper::finalizeMetadata(duk_context* ctx)
+{
+    Common::finalize<std::string>(ctx);
+    return 0;
 }
 
 duk_ret_t TorrentHandleWrapper::clearError(duk_context* ctx)
@@ -89,6 +92,13 @@ duk_ret_t TorrentHandleWrapper::getInfoHash(duk_context* ctx)
 {
     TorrentHandle* handle = Common::getPointer<TorrentHandle>(ctx);
     duk_push_string(ctx, handle->getInfoHash().c_str());
+    return 1;
+}
+
+duk_ret_t TorrentHandleWrapper::isValid(duk_context* ctx)
+{
+    TorrentHandle* handle = Common::getPointer<TorrentHandle>(ctx);
+    duk_push_boolean(ctx, handle->isValid());
     return 1;
 }
 
@@ -221,52 +231,67 @@ duk_ret_t TorrentHandleWrapper::resume(duk_context* ctx)
     return 0;
 }
 
-duk_ret_t TorrentHandleWrapper::getMetadata(duk_context* ctx)
+duk_ret_t TorrentHandleWrapper::metadata(duk_context* ctx)
 {
     TorrentHandle* handle = Common::getPointer<TorrentHandle>(ctx);
-    std::string key(duk_require_string(ctx, 0));
-    std::string val = handle->getData(key);
+    Session& sess = Poco::Util::Application::instance().getSubsystem<TorrentSubsystem>().getSession();
+    std::string hash = handle->getInfoHash();
 
-    if (val.empty())
+    switch (duk_get_top(ctx))
     {
-        duk_push_undefined(ctx);
-    }
-    else
+    case 0:
     {
-        duk_push_string(ctx, val.c_str());
-        duk_json_decode(ctx, -1);
-    }
+        duk_idx_t metaIdx = duk_push_object(ctx);
 
-    return 1;
-}
+        for (std::string key : sess.getTorrentMetadataKeys(hash))
+        {
+            std::string val = sess.getTorrentMetadata(hash, key);
 
-duk_ret_t TorrentHandleWrapper::getMetadataKeys(duk_context* ctx)
-{
-    TorrentHandle* handle = Common::getPointer<TorrentHandle>(ctx);
-    
-    duk_idx_t arrIdx = duk_push_array(ctx);
-    int i = 0;
+            if (!val.empty())
+            {
+                duk_push_string(ctx, val.c_str());
+                duk_json_decode(ctx, -1);
 
-    for (std::string key : handle->getDataKeys())
-    {
-        duk_push_string(ctx, key.c_str());
-        duk_put_prop_index(ctx, arrIdx, i);
+                duk_put_prop_string(ctx, metaIdx, key.c_str());
+            }
+        }
 
-        ++i;
+        return 1;
     }
 
-    return 1;
-}
+    case 1:
+    {
+        std::string key(duk_require_string(ctx, 0));
+        std::string val = sess.getTorrentMetadata(hash, key);
 
-duk_ret_t TorrentHandleWrapper::setMetadata(duk_context* ctx)
-{
-    TorrentHandle* handle = Common::getPointer<TorrentHandle>(ctx);
-    std::string key(duk_require_string(ctx, 0));
+        if (val.empty())
+        {
+            duk_push_undefined(ctx);
+        }
+        else
+        {
+            duk_push_string(ctx, val.c_str());
+            duk_json_decode(ctx, -1);
+        }
 
-    duk_json_encode(ctx, 1);
-    std::string val(duk_require_string(ctx, 1));
+        return 1;
+    }
 
-    handle->setData(key, val);
+    case 2:
+    {
+        std::string key(duk_require_string(ctx, 0));
+        std::string val;
+
+        if (!duk_is_undefined(ctx, 1))
+        {
+            duk_json_encode(ctx, 1);
+            std::string val(duk_require_string(ctx, 1));
+        }
+        
+        sess.setTorrentMetadata(hash, key, val);
+        break;
+    }
+    }
 
     return 0;
 }

--- a/src/scripting/scriptingsubsystem.cpp
+++ b/src/scripting/scriptingsubsystem.cpp
@@ -25,6 +25,8 @@ ScriptingSubsystem::ScriptingSubsystem()
 
 void ScriptingSubsystem::initialize(Application& app)
 {
+    std::lock_guard<std::mutex> lock(contextMutex_);
+
     AbstractConfiguration& config = app.config();
 
     std::string path = getScriptPath();
@@ -86,7 +88,11 @@ void ScriptingSubsystem::initialize(Application& app)
 void ScriptingSubsystem::uninitialize()
 {
     isRunning_ = false;
-    ticker_.join();
+    
+    if (ticker_.joinable())
+    {
+        ticker_.join();
+    }
 
     std::lock_guard<std::mutex> lock(contextMutex_);
 

--- a/win32/installer/components/scripting.wxs
+++ b/win32/installer/components/scripting.wxs
@@ -8,6 +8,10 @@
       </Component>
 
       <Component>
+        <File Name="core.js" />
+      </Component>
+
+      <Component>
         <File Name="events.js" />
       </Component>
 


### PR DESCRIPTION
I'm implementing all libtorrent alerts as events to let anyone in the JS API consume them. This will most probably include some refactoring in the existing JS API as well as existing JS events. I'll try to keep it backwards compatible.

*Todo*
* [x] `torrent_added_alert` -> `torrent.added`
* [x] `torrent_removed_alert` -> `torrent.removed`
* [ ] `read_piece_alert` -> `piece.read`
* [x] `file_completed_alert` ->  `file.completed`
* [x] `file_renamed_alert` -> `file.renamed`
* [x] `file_rename_failed_alert` -> `file.renameFailed`
* [x] `performance_alert` -> `torrent.performanceWarning`
* [x] `state_changed_alert` -> `torrent.stateChanged`
* [x] `tracker_error_alert` -> `tracker.error`
* [x] `tracker_warning_alert` -> `tracker.warning`
* [x] `scrape_reply_alert` -> `tracker.scrapeReply`
* [x] `scrape_failed_alert` -> `tracker.scrapeFailed`
* [x] `tracker_reply_alert` -> `tracker.reply`
* [x] `dht_reply_alert` -> `tracker.dhtReply`
* [x] `tracker_announce_alert` -> `tracker.announce`
* [x] `hash_failed_alert` -> `torrent.hashFailed`
* [x] `peer_ban_alert` -> `peer.ban`
* [x] `peer_unsnubbed_alert` -> `peer.unsnubbed`
* [x] `peer_snubbed_alert` -> `peer.snubbed`
* [x] `peer_error_alert` -> `peer.error`
* [x] `peer_connect_alert` -> `peer.connect`
* [x] `peer_disconnected_alert` -> `peer.disconnected`
* [ ] `invalid_request_alert` -> `peer.invalidRequest`
* [x] `torrent_finished_alert` -> `torrent.finished`
* [x] `piece_finished_alert` -> `piece.finished`
* [x] `request_dropped_alert` -> `peer.requestDropped`
* [x] `block_timeout_alert` -> `peer.blockTimeout`
* [x] `block_finished_alert` -> `peer.blockFinished`
* [x] `block_downloading_alert` -> `peer.blockDownloading`
* [x] `unwanted_block_alert` -> `peer.unwantedBlock`
* [x] `storage_moved_alert` -> `storage.moved`
* [x] `storage_moved_failed_alert` -> `storage.moveFailed`
* [x] `torrent_deleted_alert` -> `torrent.deleted`
* [x] `torrent_delete_failed_alert` -> `torrent.deleteFailed`
* [ ] `save_resume_data_alert` -> `torrent.saveResumeData`
* [ ] `save_resume_data_failed_alert` -> `torrent.saveResumeDataFailed`
* [x] `torrent_paused_alert` -> `torrent.paused`
* [x] `torrent_resumed_alert` -> `torrent.resumed`
* [x] `torrent_checked_alert` -> `torrent.checked`
* [x] `url_seed_alert` -> `torrent.urlSeed`
* [x] `file_error_alert` -> `file.error`
* [x] `metadata_failed_alert` -> `torrent.metadataFailed`
* [x] `metadata_received_alert` -> `torrent.metadataReceived`
* [ ] `udp_error_alert` -> `udpError`
* [x] `external_ip_alert` -> `externalAddress`
* [ ] `listen_failed_alert` -> `listenFailed`
* [x] `listen_succeeded_alert` -> `listenSucceeded`
* [ ] `portmap_error_alert` -> `portmapError`
* [ ] `portmap_alert` -> `portmap`
* [ ] `portmap_log_alert` -> `portmapLog`
* [ ] `fastresume_rejected_alert` -> `torrent.fastresumeRejected`
* [ ] `peer_blocked_alert` -> `peer.blocked`
* [ ] `dht_announce_alert` -> `dht.announce`
* [ ] `dht_get_peers_alert` -> `dht.getPeers`
* [x] `stats_alert` -> `torrent.stats`
* [x] `cache_flushed_alert` -> `torrent.cacheFlushed`
* [ ] `anonymous_mode_alert` -> `torrent.anonymousMode`
* [x] `lsd_peer_alert` -> `peer.lsd`
* [x] `trackerid_alert` -> `tracker.id`
* [x] `dht_bootstrap_alert` -> `dht.bootstrap`
* [x] `torrent_error_alert` -> `torrent.error`
* [x] `torrent_need_cert_alert` -> `torrent.needCertificate`
* [x] `incoming_connection_alert` -> `incomingConnection`
* [ ] `add_torrent_alert` -> `torrent.add`
* [ ] `state_update_alert` -> `stateUpdate`
* [ ] `torrent_update_alert` -> `torrent.update`
* [ ] `dht_error_alert` -> `dht.error`
* [ ] `dht_immutable_item_alert` -> `dht.immutableItem`
* [ ] `dht_mutable_item_alert` -> `dht.mutableItem`
* [ ] `dht_put_alert` -> `dht.put`
* [ ] `i2p_alert` -> `i2p`