### PR TITLE
[WIP] RSS

### DIFF
--- a/include/hadouken/platform.hpp
+++ b/include/hadouken/platform.hpp
@@ -26,6 +26,8 @@ namespace hadouken
 
         static boost::filesystem::path application_path();
 
+        static boost::filesystem::path get_current_directory();
+
         static int launch_process(std::string executable, std::vector<std::string> args);
     };
 }

--- a/include/hadouken/scripting/modules/bittorrent/alert_wrapper.hpp
+++ b/include/hadouken/scripting/modules/bittorrent/alert_wrapper.hpp
@@ -40,6 +40,7 @@ namespace libtorrent
     struct portmap_log_alert;
     struct read_piece_alert;
     struct request_dropped_alert;
+    struct rss_alert;
     struct save_resume_data_alert;
     struct save_resume_data_failed_alert;
     struct scrape_failed_alert;
@@ -143,6 +144,7 @@ namespace hadouken
                     static int initialize(void* ctx, libtorrent::lsd_peer_alert* alert);
                     static int initialize(void* ctx, libtorrent::trackerid_alert* alert);
                     static int initialize(void* ctx, libtorrent::dht_bootstrap_alert* alert);
+                    static int initialize(void* ctx, libtorrent::rss_alert* alert);
                     static int initialize(void* ctx, libtorrent::torrent_error_alert* alert);
                     static int initialize(void* ctx, libtorrent::torrent_need_cert_alert* alert);
                     static int initialize(void* ctx, libtorrent::incoming_connection_alert* alert);

--- a/include/hadouken/scripting/modules/bittorrent/feed_handle_wrapper.hpp
+++ b/include/hadouken/scripting/modules/bittorrent/feed_handle_wrapper.hpp
@@ -1,0 +1,35 @@
+#ifndef HADOUKEN_SCRIPTING_MODULES_BITTORRENT_FEEDHANDLEWRAPPER_HPP
+#define HADOUKEN_SCRIPTING_MODULES_BITTORRENT_FEEDHANDLEWRAPPER_HPP
+
+namespace libtorrent
+{
+    struct feed_handle;
+}
+
+namespace hadouken
+{
+    namespace scripting
+    {
+        namespace modules
+        {
+            namespace bittorrent
+            {
+                class feed_handle_wrapper
+                {
+                public:
+                    static void initialize(void* ctx, const libtorrent::feed_handle& handle);
+
+                private:
+                    static int finalize(void* ctx);
+
+                    static int update_feed(void* ctx);
+                    static int get_feed_status(void* ctx);
+                    static int set_settings(void* ctx);
+                    static int get_settings(void* ctx);
+                };
+            }
+        }
+    }
+}
+
+#endif

--- a/include/hadouken/scripting/modules/bittorrent/feed_settings_wrapper.hpp
+++ b/include/hadouken/scripting/modules/bittorrent/feed_settings_wrapper.hpp
@@ -1,0 +1,38 @@
+#ifndef HADOUKEN_SCRIPTING_MODULES_BITTORRENT_FEEDSETTINGSWRAPPER_HPP
+#define HADOUKEN_SCRIPTING_MODULES_BITTORRENT_FEEDSETTINGSWRAPPER_HPP
+
+#define DUK_PROP(name) \
+    static int get_##name(void* ctx); \
+    static int set_##name(void* ctx);
+
+namespace libtorrent
+{
+    struct feed_settings;
+}
+
+namespace hadouken
+{
+    namespace scripting
+    {
+        namespace modules
+        {
+            namespace bittorrent
+            {
+                class feed_settings_wrapper
+                {
+                public:
+                    static int construct(void* ctx);
+
+                private:
+                    static int finalize(void* ctx);
+                    
+                    DUK_PROP(url);
+                    DUK_PROP(ttl);
+                    DUK_PROP(auto_download);
+                };
+            }
+        }
+    }
+}
+
+#endif

--- a/include/hadouken/scripting/modules/bittorrent/feed_status_wrapper.hpp
+++ b/include/hadouken/scripting/modules/bittorrent/feed_status_wrapper.hpp
@@ -1,0 +1,38 @@
+#ifndef HADOUKEN_SCRIPTING_MODULES_BITTORRENT_FEEDSTATUSWRAPPER_HPP
+#define HADOUKEN_SCRIPTING_MODULES_BITTORRENT_FEEDSTATUSWRAPPER_HPP
+
+namespace libtorrent
+{
+    struct feed_status;
+}
+
+namespace hadouken
+{
+    namespace scripting
+    {
+        namespace modules
+        {
+            namespace bittorrent
+            {
+                class feed_status_wrapper
+                {
+                public:
+                    static void initialize(void* ctx, const libtorrent::feed_status& status);
+
+                private:
+                    static int finalize(void* ctx);
+
+                    static int get_items(void* ctx);
+                    static int get_last_update(void* ctx);
+                    static int get_next_update(void* ctx);
+                    static int get_description(void* ctx);
+                    static int get_url(void* ctx);
+                    static int get_title(void* ctx);
+                    static int is_updating(void* ctx);
+                };
+            }
+        }
+    }
+}
+
+#endif

--- a/include/hadouken/scripting/modules/bittorrent/session_wrapper.hpp
+++ b/include/hadouken/scripting/modules/bittorrent/session_wrapper.hpp
@@ -21,11 +21,13 @@ namespace hadouken
 
                 private:
                     static int add_dht_router(void* ctx);
+                    static int add_feed(void* ctx);
                     static int add_torrent(void* ctx);
                     static int find_torrent(void* ctx);
                     static int get_listen_port(void* ctx);
                     static int get_ssl_listen_port(void* ctx);
                     static int get_alerts(void* ctx);
+                    static int get_feeds(void* ctx);
                     static int get_settings(void* ctx);
                     static int get_status(void* ctx);
                     static int get_torrents(void* ctx);

--- a/js/bittorrent.js
+++ b/js/bittorrent.js
@@ -53,7 +53,8 @@ var eventMap = {
     "tracker.reply":               "tracker_reply_alert",
     "tracker.warning":             "tracker_warning_alert",
     "peer.unwantedBlock":          "unwanted_block_alert",
-    "torrent.urlSeed":             "url_seed_alert"
+    "torrent.urlSeed":             "url_seed_alert",
+    "rss":                         "rss_alert"
 };
 
 /*

--- a/js/rpc/rss_getFeedItems.js
+++ b/js/rpc/rss_getFeedItems.js
@@ -1,0 +1,43 @@
+var session = require("bittorrent").session;
+
+function getFeedStatus(url) {
+    var feeds  = session.getFeeds();
+
+    for(var i = 0; i < feeds.length; i++) {
+        var status = feeds[i].getStatus();
+
+        if(status.url === url) {
+            return status;
+        }
+    }
+}
+
+exports.rpc = {
+    name: "rss.getFeedItems",
+    method: function(url) {
+        var result = [];
+        var status = getFeedStatus(url);
+
+        if(typeof status === "undefined") {
+            throw new Error("Unknown feed url.");
+        }
+
+        var items  = status.getItems();
+
+        for(var i = 0; i < items.length; i++) {
+            var item = items[i];
+
+            result.push({
+                uuid: item.uuid,
+                url: item.url,
+                title: item.title,
+                description: item.description,
+                comment: item.comment,
+                category: item.category,
+                size: item.size
+            });
+        }
+
+        return result;
+    }
+};

--- a/js/rpc/rss_getFeeds.js
+++ b/js/rpc/rss_getFeeds.js
@@ -1,0 +1,25 @@
+var session = require("bittorrent").session;
+
+exports.rpc = {
+    name: "rss.getFeeds",
+    method: function() {
+        var feeds  = session.getFeeds();
+        var result = {};
+
+        for(var i = 0; i < feeds.length; i++) {
+            var status = feeds[i].getStatus();
+
+            result[status.url] = {
+                url: status.url,
+                title: status.title,
+                description: status.description,
+                lastUpdate: status.lastUpdate,
+                nextUpdate: status.nextUpdate,
+                isUpdating: status.isUpdating,
+                items: status.getItems().length
+            };
+        }
+
+        return result;
+    }
+};

--- a/js/rss.js
+++ b/js/rss.js
@@ -1,0 +1,176 @@
+var bt       = require("bittorrent");
+var config   = require("config");
+var fs       = require("fs");
+var logger   = require("logger").get("rss");
+var metadata = require("metadata");
+var session  = bt.session;
+
+// Constants
+var STATE_UPDATING = 0;
+var STATE_UPDATED  = 1;
+var STATE_ERROR    = 2;
+
+// Our managed feeds
+var feeds = [];
+
+// Prototypes for feeds and filters
+function Feed(url, filter, options) {
+    this.url = url;
+    this.history = [];
+    this.options = options || {};
+
+    if(typeof filter === "string" && filter === "*") {
+        this.filter = new CatchAllFilter();
+    } else if(filter instanceof Array) {
+        var type = filter[0];
+
+        if(type === "regex") {
+            this.filter = new RegExpFilter(filter[1], filter[2]);
+        } else {
+            this.filter = new Filter();
+        }
+    } else {
+        this.filter = new Filter();
+    }
+}
+
+Feed.find = function(url) {
+    for(var i = 0; i < feeds.length; i++) {
+        if(feeds[i].url === url) {
+            return feeds[i];
+        }
+    }
+}
+
+function Filter() {}
+Filter.prototype.isMatch = function() { return false; };
+
+function CatchAllFilter() {}
+CatchAllFilter.prototype.isMatch = function() { return true; }
+
+function RegExpFilter(include, exclude) {
+    this.include = new RegExp(include);
+
+    if(typeof exclude !== "undefined") {
+        this.exclude = new RegExp(exclude);
+    }
+}
+
+RegExpFilter.prototype.isMatch = function(input) {
+    if(typeof this.exclude !== "undefined") {
+        return this.include.test(input) && !this.exclude.test(input);
+    }
+
+    return this.include.test(input);
+}
+
+function download(item, options) {
+    var p  = bt.AddTorrentParams.getDefault();
+    p.url  = item.url;
+
+    if(options.savePath) {
+        p.savePath = options.savePath;
+    }
+
+    session.addTorrent(p);
+}
+
+function onRss(arg) {
+    if(arg.state === STATE_ERROR) {
+        logger.error("Error when updating feed '" + arg.url + "'.");
+        return;
+    }
+
+    if(arg.state === STATE_UPDATING) {
+        return;
+    }
+
+    // Every time a feed is updated, loop through the items and
+    // match each item against the filter specified for this feed.
+
+    var status = arg.feed.getStatus();
+    var feed   = Feed.find(status.url);
+    var items  = status.getItems();
+
+    for(var i = 0; i < items.length; i++) {
+        var item = items[i];
+
+        // Skip item if it exists in feed history.
+        if(feed.history.indexOf(item.uuid) > -1) {
+            continue;
+        }
+
+        // Skip item if the filter does not match.
+        if(!feed.filter.isMatch(item.title)) {
+            continue;
+        }
+
+        if(feed.options.dryRun) {
+            logger.debug("(RSS DRY-RUN): Adding torrent " + item.title);
+        } else {
+            // Push the uuid to the feed history and
+            // download the item.
+            feed.history.push(item.uuid);
+            download(item, feed.options);
+        }
+    }
+}
+
+function loadState() {
+    var statePath = config.getString("bittorrent.statePath") || "state";
+    var stateFile = fs.combine(statePath, ".rss_state");
+
+    if(!fs.fileExists(stateFile)) {
+        logger.debug("No previous RSS state to load.");
+        return;
+    }
+
+    var contents = fs.readText(stateFile);
+    var state    = JSON.parse(contents);
+
+    return state;
+}
+
+function load() {
+    session.on("rss", onRss);
+
+    var configuredFeeds = config.get("feeds") || [];
+    var state           = loadState() || {};
+
+    for(var i = 0; i < configuredFeeds.length; i++) {
+        var feed          = new bt.FeedSettings();
+        feed.url          = configuredFeeds[i].url;
+        feed.ttl          = configuredFeeds[i].ttl || 30;
+        feed.autoDownload = false;
+
+        var f = new Feed(feed.url, configuredFeeds[i].filter, configuredFeeds[i].options);
+
+        if(state[f.url]) {
+            f.history = state[f.url] || [];
+        }
+
+        feeds.push(f);
+        session.addFeed(feed);
+    }
+}
+
+function saveState() {
+    var statePath = config.getString("bittorrent.statePath") || "state";
+    var stateFile = fs.combine(statePath, ".rss_state");
+
+    var state = {};
+
+    for(var i = 0; i < feeds.length; i++) {
+        state[feeds[i].url] = feeds[i].history;
+    }
+
+    fs.writeText(stateFile, JSON.stringify(state, 2, ' '));
+    logger.info("RSS state saved to " + stateFile);
+}
+
+function unload() {
+    saveState();
+}
+
+exports.load = load;
+exports.unload = unload;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -49,7 +49,7 @@ fs::path get_config_path(const po::variables_map& options)
     }
     else
     {
-        return (hadouken::platform::application_path() / "hadouken.json");
+        return (hadouken::platform::get_current_directory() / "hadouken.json");
     }
 }
 
@@ -70,6 +70,9 @@ int main(int argc, char *argv[])
     po::variables_map vm = load_options(argc, argv);
     hadouken::logging::setup(vm);
 
+    // Do platform-specific initialization as early as possible.
+    hadouken::platform::init();
+
 #ifdef WIN32
     if (vm.count("install-service"))
     {
@@ -82,9 +85,6 @@ int main(int argc, char *argv[])
         return 0;
     }
 #endif
-
-    // Do platform-specific initialization as early as possible.
-    hadouken::platform::init();
 
     fs::path config_file = get_config_path(vm);
     pt::ptree config;

--- a/src/platform_win32.cpp
+++ b/src/platform_win32.cpp
@@ -162,6 +162,14 @@ boost::filesystem::path platform::application_path()
     return boost::filesystem::path(szPath).parent_path();
 }
 
+boost::filesystem::path platform::get_current_directory()
+{
+    TCHAR buffer[MAX_PATH];
+    GetCurrentDirectory(MAX_PATH, buffer);
+
+    return boost::filesystem::path(buffer);
+}
+
 int platform::launch_process(std::string executable, std::vector<std::string> args)
 {
     // TODO

--- a/src/scripting/modules/bittorrent/alert_wrapper.cpp
+++ b/src/scripting/modules/bittorrent/alert_wrapper.cpp
@@ -1,6 +1,7 @@
 #include <hadouken/scripting/modules/bittorrent/alert_wrapper.hpp>
 
 #include <hadouken/scripting/modules/bittorrent/entry_wrapper.hpp>
+#include <hadouken/scripting/modules/bittorrent/feed_handle_wrapper.hpp>
 #include <hadouken/scripting/modules/bittorrent/torrent_handle_wrapper.hpp>
 #include <libtorrent/alert_types.hpp>
 
@@ -81,7 +82,7 @@ void alert_wrapper::construct(duk_context* ctx, libtorrent::alert* alert)
         ALERT_CASE(lsd_peer_alert)
         ALERT_CASE(trackerid_alert)
         ALERT_CASE(dht_bootstrap_alert)
-        //ALERT_CASE(rss_alert)
+        ALERT_CASE(rss_alert)
         ALERT_CASE(torrent_error_alert)
         ALERT_CASE(torrent_need_cert_alert)
         //ALERT_CASE(add_torrent_alert)
@@ -796,6 +797,22 @@ duk_idx_t alert_wrapper::initialize(duk_context* ctx, libtorrent::trackerid_aler
 duk_idx_t alert_wrapper::initialize(duk_context* ctx, libtorrent::dht_bootstrap_alert* alert)
 {
     return alert_wrapper::initialize(ctx, static_cast<libtorrent::alert*>(alert));
+}
+
+duk_idx_t alert_wrapper::initialize(duk_context* ctx, libtorrent::rss_alert* alert)
+{
+    duk_idx_t idx = alert_wrapper::initialize(ctx, static_cast<libtorrent::alert*>(alert));
+
+    duk_push_string(ctx, alert->url.c_str());
+    duk_put_prop_string(ctx, idx, "url");
+
+    duk_push_int(ctx, alert->state);
+    duk_put_prop_string(ctx, idx, "state");
+
+    feed_handle_wrapper::initialize(ctx, alert->handle);
+    duk_put_prop_string(ctx, idx, "feed");
+
+    return idx;
 }
 
 duk_idx_t alert_wrapper::initialize(duk_context* ctx, libtorrent::torrent_error_alert* alert)

--- a/src/scripting/modules/bittorrent/feed_handle_wrapper.cpp
+++ b/src/scripting/modules/bittorrent/feed_handle_wrapper.cpp
@@ -1,0 +1,58 @@
+#include <hadouken/scripting/modules/bittorrent/feed_handle_wrapper.hpp>
+
+#include <hadouken/scripting/modules/bittorrent/feed_status_wrapper.hpp>
+#include <libtorrent/rss.hpp>
+
+#include "../common.hpp"
+#include "../../duktape.h"
+
+using namespace hadouken::scripting::modules;
+using namespace hadouken::scripting::modules::bittorrent;
+
+void feed_handle_wrapper::initialize(duk_context* ctx, const libtorrent::feed_handle& handle)
+{
+    duk_function_list_entry functions[] =
+    {
+        { "updateFeed",  update_feed,     0 },
+        { "getStatus",   get_feed_status, 0 },
+        { "getSettings", get_settings,    0 },
+        { "setSettings", set_settings,    1 },
+        { NULL,          NULL,            0 }
+    };
+
+    duk_idx_t idx = duk_push_object(ctx);
+    duk_put_function_list(ctx, idx, functions);
+
+    common::set_pointer<libtorrent::feed_handle>(ctx, idx, new libtorrent::feed_handle(handle));
+
+    duk_push_c_function(ctx, finalize, 1);
+    duk_set_finalizer(ctx, -2);
+}
+
+duk_ret_t feed_handle_wrapper::finalize(duk_context* ctx)
+{
+    common::finalize<libtorrent::feed_handle>(ctx);
+    return 0;
+}
+
+duk_ret_t feed_handle_wrapper::update_feed(duk_context* ctx)
+{
+    return 0;
+}
+
+duk_ret_t feed_handle_wrapper::get_feed_status(duk_context* ctx)
+{
+    libtorrent::feed_handle* handle = common::get_pointer<libtorrent::feed_handle>(ctx);
+    feed_status_wrapper::initialize(ctx, handle->get_feed_status());
+    return 1;
+}
+
+duk_ret_t feed_handle_wrapper::get_settings(duk_context* ctx)
+{
+    return 0;
+}
+
+duk_ret_t feed_handle_wrapper::set_settings(duk_context* ctx)
+{
+    return 0;
+}

--- a/src/scripting/modules/bittorrent/feed_settings_wrapper.cpp
+++ b/src/scripting/modules/bittorrent/feed_settings_wrapper.cpp
@@ -1,0 +1,75 @@
+#include <hadouken/scripting/modules/bittorrent/feed_settings_wrapper.hpp>
+
+#include <libtorrent/rss.hpp>
+
+#include "../common.hpp"
+#include "../../duktape.h"
+
+using namespace hadouken::scripting::modules;
+using namespace hadouken::scripting::modules::bittorrent;
+
+duk_ret_t feed_settings_wrapper::construct(duk_context* ctx)
+{
+    duk_push_this(ctx);
+
+    // Set internal pointer
+    common::set_pointer<libtorrent::feed_settings>(ctx, -2, new libtorrent::feed_settings());
+
+    DUK_READWRITE_PROPERTY(ctx, -4, url, url);
+    DUK_READWRITE_PROPERTY(ctx, -4, ttl, ttl);
+    DUK_READWRITE_PROPERTY(ctx, -4, autoDownload, auto_download);
+
+    // Set finalizer
+    duk_push_c_function(ctx, finalize, 1);
+    duk_set_finalizer(ctx, -2);
+
+    return 0;
+}
+
+duk_ret_t feed_settings_wrapper::finalize(duk_context* ctx)
+{
+    common::finalize<libtorrent::feed_settings>(ctx);
+    return 0;
+}
+
+duk_ret_t feed_settings_wrapper::get_auto_download(duk_context* ctx)
+{
+    bool auto_dl = common::get_pointer<libtorrent::feed_settings>(ctx)->auto_download;
+    duk_push_boolean(ctx, auto_dl);
+    return 1;
+}
+
+duk_ret_t feed_settings_wrapper::get_url(duk_context* ctx)
+{
+    std::string url = common::get_pointer<libtorrent::feed_settings>(ctx)->url;
+    duk_push_string(ctx, url.c_str());
+    return 1;
+}
+
+duk_ret_t feed_settings_wrapper::get_ttl(duk_context* ctx)
+{
+    int ttl = common::get_pointer<libtorrent::feed_settings>(ctx)->default_ttl;
+    duk_push_int(ctx, ttl);
+    return 1;
+}
+
+duk_ret_t feed_settings_wrapper::set_auto_download(duk_context* ctx)
+{
+    bool auto_dl = duk_require_boolean(ctx, 0);
+    common::get_pointer<libtorrent::feed_settings>(ctx)->auto_download = auto_dl;
+    return 0;
+}
+
+duk_ret_t feed_settings_wrapper::set_url(duk_context* ctx)
+{
+    std::string url = duk_require_string(ctx, 0);
+    common::get_pointer<libtorrent::feed_settings>(ctx)->url = url;
+    return 0;
+}
+
+duk_ret_t feed_settings_wrapper::set_ttl(duk_context* ctx)
+{
+    int ttl = duk_require_int(ctx, 0);
+    common::get_pointer<libtorrent::feed_settings>(ctx)->default_ttl = ttl;
+    return 0;
+}

--- a/src/scripting/modules/bittorrent/feed_status_wrapper.cpp
+++ b/src/scripting/modules/bittorrent/feed_status_wrapper.cpp
@@ -1,0 +1,121 @@
+#include <hadouken/scripting/modules/bittorrent/feed_status_wrapper.hpp>
+
+#include <libtorrent/rss.hpp>
+
+#include "../common.hpp"
+#include "../../duktape.h"
+
+using namespace hadouken::scripting::modules;
+using namespace hadouken::scripting::modules::bittorrent;
+
+void feed_status_wrapper::initialize(duk_context* ctx, const libtorrent::feed_status& status)
+{
+    duk_idx_t idx = duk_push_object(ctx);
+
+    duk_function_list_entry functions[] =
+    {
+        { "getItems", get_items, 0 },
+        { NULL,       NULL,      0 }
+    };
+
+    duk_put_function_list(ctx, idx, functions);
+
+    DUK_READONLY_PROPERTY(ctx, idx, description, get_description);
+    DUK_READONLY_PROPERTY(ctx, idx, lastUpdate, get_last_update);
+    DUK_READONLY_PROPERTY(ctx, idx, nextUpdate, get_next_update);
+    DUK_READONLY_PROPERTY(ctx, idx, isUpdating, is_updating);
+    DUK_READONLY_PROPERTY(ctx, idx, url, get_url);
+    DUK_READONLY_PROPERTY(ctx, idx, title, get_title);
+
+    common::set_pointer<libtorrent::feed_status>(ctx, idx, new libtorrent::feed_status(status));
+
+    duk_push_c_function(ctx, finalize, 1);
+    duk_set_finalizer(ctx, -2);
+}
+
+duk_ret_t feed_status_wrapper::finalize(duk_context* ctx)
+{
+    common::finalize<libtorrent::feed_status>(ctx);
+    return 0;
+}
+
+duk_ret_t feed_status_wrapper::get_items(duk_context* ctx)
+{
+    libtorrent::feed_status* status = common::get_pointer<libtorrent::feed_status>(ctx);
+
+    duk_idx_t arrIdx = duk_push_array(ctx);
+    int i = 0;
+
+    for (libtorrent::feed_item item : status->items)
+    {
+        duk_idx_t itemIdx = duk_push_object(ctx);
+
+        duk_push_string(ctx, item.url.c_str());
+        duk_put_prop_string(ctx, itemIdx, "url");
+
+        duk_push_string(ctx, item.uuid.c_str());
+        duk_put_prop_string(ctx, itemIdx, "uuid");
+
+        duk_push_string(ctx, item.title.c_str());
+        duk_put_prop_string(ctx, itemIdx, "title");
+
+        duk_push_string(ctx, item.description.c_str());
+        duk_put_prop_string(ctx, itemIdx, "description");
+
+        duk_push_string(ctx, item.comment.c_str());
+        duk_put_prop_string(ctx, itemIdx, "comment");
+
+        duk_push_string(ctx, item.category.c_str());
+        duk_put_prop_string(ctx, itemIdx, "category");
+
+        duk_push_number(ctx, item.size);
+        duk_put_prop_string(ctx, itemIdx, "size");
+
+        duk_put_prop_index(ctx, arrIdx, i);
+        ++i;
+    }
+
+    return 1;
+}
+
+duk_ret_t feed_status_wrapper::get_description(duk_context* ctx)
+{
+    libtorrent::feed_status* status = common::get_pointer<libtorrent::feed_status>(ctx);
+    duk_push_string(ctx, status->description.c_str());
+    return 1;
+}
+
+duk_ret_t feed_status_wrapper::get_last_update(duk_context* ctx)
+{
+    libtorrent::feed_status* status = common::get_pointer<libtorrent::feed_status>(ctx);
+    duk_push_number(ctx, status->last_update);
+    return 1;
+}
+
+duk_ret_t feed_status_wrapper::get_next_update(duk_context* ctx)
+{
+    libtorrent::feed_status* status = common::get_pointer<libtorrent::feed_status>(ctx);
+    duk_push_number(ctx, status->next_update);
+    return 1;
+}
+
+duk_ret_t feed_status_wrapper::is_updating(duk_context* ctx)
+{
+    libtorrent::feed_status* status = common::get_pointer<libtorrent::feed_status>(ctx);
+    duk_push_boolean(ctx, status->updating);
+    return 1;
+}
+
+duk_ret_t feed_status_wrapper::get_url(duk_context* ctx)
+{
+    libtorrent::feed_status* status = common::get_pointer<libtorrent::feed_status>(ctx);
+    duk_push_string(ctx, status->url.c_str());
+    return 1;
+}
+
+duk_ret_t feed_status_wrapper::get_title(duk_context* ctx)
+{
+    libtorrent::feed_status* status = common::get_pointer<libtorrent::feed_status>(ctx);
+    duk_push_string(ctx, status->title.c_str());
+    return 1;
+}

--- a/src/scripting/modules/bittorrent_module.cpp
+++ b/src/scripting/modules/bittorrent_module.cpp
@@ -1,6 +1,7 @@
 #include <hadouken/scripting/modules/bittorrent_module.hpp>
 
 #include <hadouken/scripting/modules/bittorrent/add_torrent_params_wrapper.hpp>
+#include <hadouken/scripting/modules/bittorrent/feed_settings_wrapper.hpp>
 #include <hadouken/scripting/modules/bittorrent/session_wrapper.hpp>
 #include <hadouken/scripting/modules/bittorrent/torrent_creator_wrapper.hpp>
 #include <hadouken/scripting/modules/bittorrent/torrent_info_wrapper.hpp>
@@ -21,6 +22,9 @@ duk_ret_t bittorrent_module::initialize(duk_context* ctx, libtorrent::session& s
 
     duk_push_c_function(ctx, add_torrent_params_wrapper::construct, 0);
     duk_put_prop_string(ctx, 2, "AddTorrentParams");
+
+    duk_push_c_function(ctx, feed_settings_wrapper::construct, 0);
+    duk_put_prop_string(ctx, 2, "FeedSettings");
 
     duk_push_c_function(ctx, torrent_creator_wrapper::construct, 1);
     duk_put_prop_string(ctx, 2, "TorrentCreator");

--- a/win32/installer/components/scripting.wxs
+++ b/win32/installer/components/scripting.wxs
@@ -40,6 +40,10 @@
       </Component>
 
       <Component>
+        <File Name="rss.js" />
+      </Component>
+
+      <Component>
         <File Name="timer.js" />
       </Component>
     </ComponentGroup>
@@ -73,6 +77,14 @@
 
       <Component>
         <File Name="core_getSystemInfo.js" />
+      </Component>
+
+      <Component>
+        <File Name="rss_getFeedItems.js" />
+      </Component>
+
+      <Component>
+        <File Name="rss_getFeeds.js" />
       </Component>
 
       <Component>


### PR DESCRIPTION
Implementing the RSS part of Hadouken. It builds on the functions already in `libtorrent`. A few simple JS wrappers and then settle on some configuration.

**Todo**

 - [x] JS wrappers
 - [x] Decide on config
 - [x] RPC methods to view feeds
 - [x] Store UUID's of added feed items to avoid duplicates

**Configuration examples**

Download everything from a feed,

```js
{ "url": "http://some-rss.feed/", "filter": "*" }
```

Optionally specify a different save path,

```js
{
  "url": "http://some-rss.feed/",
  "filter": "*",
  "options": { "savePath": "C:/My/RSS/Downloads" }
}
```

Filter on a regular expression,

```js
{
  "url": "http://some-rss.feed/",
  "filter": [ "regex", "^.*720p.*$" ]
}
```

Optionally pass a second pattern to the `regex` filter which is another expression for excluding items. The example below will download all items containing `720p` exclude all items containing `NUKED`.

```js
{
  "url": "http://some-rss.feed/",
  "filter": [ "regex", "720p", "NUKED" ]
}
```

**RPC methods**

Two new JSONRPC methods have been added.

`rss.getFeeds` returns a dictionary (with feed url as key) of all feeds.

`rss.getFeedItems(url)` returns a list of all items in the feed specified by the url parameter.

**State**

The RSS functionality stores the `uuid` of all items it downloads to avoid downloading duplicates. This is a simple JSON dictionary with the feed url as a key and an array of `uuid` items as value,

```js
{
  "<rss feed url>": [
    "uuid-1",
    "uuid-2"
  ]
}
```

This file is saved at `%statedir%/.rss_state`.