### PR TITLE
Implemented seed goals.

### DIFF
--- a/docs/src/configuration.rst
+++ b/docs/src/configuration.rst
@@ -76,6 +76,38 @@ Disabling DHT
 .. note:: The `routers` are ignored if DHT is disabled.
 
 
+Seed goals
+``````````
+
+Each torrent in Hadouken can be paused or removed when it reaches the
+user-specified seed goals. If no default options are specified, the seed
+goal is set to `2.0` however no action is configured.
+
+To pause a torrent when it reaches the seed goal, use the following
+configuration.
+
+.. note:: Only torrents added after the configuration change will get the
+          new default options. Each torrent remembers its own options.
+
+.. code:: javascript
+
+   {
+     "bittorrent":
+     {
+       "defaultOptions":
+       {
+         "seedRatio": 2.0,
+         "seedRatioAction": "pause"
+       }
+     }
+   }
+
+Available actions are,
+
+ * `pause`
+ * `remove`
+
+
 Storage allocation
 ``````````````````
 

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -67,7 +67,6 @@ documentation for your specific platform.
 .. toctree::
    :maxdepth: 1
 
-   installing/ubuntu
    installing/windows
 
 

--- a/include/hadouken/scripting/modules/bittorrent/alert_wrapper.hpp
+++ b/include/hadouken/scripting/modules/bittorrent/alert_wrapper.hpp
@@ -48,6 +48,7 @@ namespace libtorrent
     struct scrape_failed_alert;
     struct scrape_reply_alert;
     struct state_changed_alert;
+    struct state_update_alert;
     struct stats_alert;
     struct storage_moved_alert;
     struct storage_moved_failed_alert;
@@ -152,6 +153,7 @@ namespace hadouken
                     static int initialize(void* ctx, libtorrent::torrent_need_cert_alert* alert);
                     static int initialize(void* ctx, libtorrent::incoming_connection_alert* alert);
                     static int initialize(void* ctx, libtorrent::add_torrent_alert* alert);
+                    static int initialize(void* ctx, libtorrent::state_update_alert* alert);
                     static int initialize(void* ctx, libtorrent::torrent_update_alert* alert);
                     static int initialize(void* ctx, libtorrent::i2p_alert* alert);
 

--- a/include/hadouken/scripting/modules/bittorrent/session_wrapper.hpp
+++ b/include/hadouken/scripting/modules/bittorrent/session_wrapper.hpp
@@ -37,6 +37,7 @@ namespace hadouken
                     static int load_country_db(void* ctx);
                     static int load_state(void* ctx);
                     static int pause(void* ctx);
+                    static int post_torrent_updates(void* ctx);
                     static int remove_torrent(void* ctx);
                     static int resume(void* ctx);
                     static int save_state(void* ctx);

--- a/include/hadouken/scripting/modules/bittorrent/torrent_status_wrapper.hpp
+++ b/include/hadouken/scripting/modules/bittorrent/torrent_status_wrapper.hpp
@@ -24,6 +24,7 @@ namespace hadouken
 
                     static int get_error(void* ctx);
                     static int get_name(void* ctx);
+                    static int get_eta(void* ctx);
                     static int get_progress(void* ctx);
                     static int get_save_path(void* ctx);
                     static int get_download_rate(void* ctx);
@@ -34,7 +35,9 @@ namespace hadouken
                     static int get_uploaded_bytes_total(void* ctx);
                     static int get_num_peers(void* ctx);
                     static int get_num_seeds(void* ctx);
+                    static int get_ratio(void* ctx);
                     static int get_state(void* ctx);
+                    static int get_handle(void* ctx);
                     static int has_metadata(void* ctx);
                     static int is_finished(void* ctx);
                     static int is_moving_storage(void* ctx);

--- a/js/bittorrent.js
+++ b/js/bittorrent.js
@@ -33,6 +33,7 @@ var eventMap = {
     "tracker.scrapeReply":         "scrape_reply_alert",
     "tracker.scrapeFailed":        "scrape_failed_alert",
     "torrent.stateChanged":        "state_changed_alert",
+    "torrent.stateUpdate":         "state_update_alert",
     "torrent.stats":               "stats_alert",
     "torrent.moved":               "storage_moved_alert",
     "torrent.moveFailed":          "storage_moved_failed_alert",

--- a/js/rpc/session_getTorrents.js
+++ b/js/rpc/session_getTorrents.js
@@ -10,7 +10,7 @@ exports.rpc = {
             var torrent = torrents[i];
             var status  = torrent.getStatus();
             var info    = torrent.getTorrentInfo();
-
+            
             var totalSize = -1;
             if(info) totalSize = info.totalSize;
 
@@ -36,7 +36,9 @@ exports.rpc = {
                 isSeeding:            status.isSeeding,
                 isSequentialDownload: status.isSequentialDownload,
                 queuePosition:        torrent.queuePosition,
-                tags:                 torrent.tags
+                tags:                 torrent.metadata("tags"),
+                ratio:                status.ratio,
+                eta:                  status.eta
             };
         }
 

--- a/src/scripting/modules/bittorrent/alert_wrapper.cpp
+++ b/src/scripting/modules/bittorrent/alert_wrapper.cpp
@@ -5,6 +5,7 @@
 #include <hadouken/scripting/modules/bittorrent/error_code_wrapper.hpp>
 #include <hadouken/scripting/modules/bittorrent/feed_handle_wrapper.hpp>
 #include <hadouken/scripting/modules/bittorrent/torrent_handle_wrapper.hpp>
+#include <hadouken/scripting/modules/bittorrent/torrent_status_wrapper.hpp>
 #include <libtorrent/alert_types.hpp>
 
 #include "../common.hpp"
@@ -88,7 +89,7 @@ void alert_wrapper::construct(duk_context* ctx, libtorrent::alert* alert)
         ALERT_CASE(torrent_error_alert)
         ALERT_CASE(torrent_need_cert_alert)
         ALERT_CASE(add_torrent_alert)
-        //ALERT_CASE(state_update_alert)
+        ALERT_CASE(state_update_alert)
         ALERT_CASE(torrent_update_alert)
         //ALERT_CASE(rss_item_alert)
         //ALERT_CASE(dht_error_alert)
@@ -936,6 +937,32 @@ duk_idx_t alert_wrapper::initialize(duk_context* ctx, libtorrent::add_torrent_al
 
     add_torrent_params_wrapper::initialize(ctx, alert->params);
     duk_put_prop_string(ctx, idx, "params");
+
+    if (alert->error)
+    {
+        error_code_wrapper::initialize(ctx, alert->error);
+        duk_put_prop_string(ctx, idx, "error");
+    }
+
+    return idx;
+}
+
+duk_idx_t alert_wrapper::initialize(duk_context* ctx, libtorrent::state_update_alert* alert)
+{
+    duk_idx_t idx = alert_wrapper::initialize(ctx, static_cast<libtorrent::alert*>(alert));
+
+    duk_idx_t arrIdx = duk_push_array(ctx);
+    int i = 0;
+
+    for (libtorrent::torrent_status status : alert->status)
+    {
+        torrent_status_wrapper::initialize(ctx, status);
+        duk_put_prop_index(ctx, arrIdx, i);
+
+        ++i;
+    }
+
+    duk_put_prop_string(ctx, idx, "status");
 
     return idx;
 }

--- a/src/scripting/modules/bittorrent/session_wrapper.cpp
+++ b/src/scripting/modules/bittorrent/session_wrapper.cpp
@@ -46,6 +46,7 @@ void session_wrapper::initialize(duk_context* ctx, libtorrent::session& session)
         { "loadCountryDb",  load_country_db,1 },
         { "loadState",      load_state,     1 },
         { "pause",          pause,          0 },
+        { "postTorrentUpdates", post_torrent_updates, 0 },
         { "removeTorrent",  remove_torrent, 2 },
         { "resume",         resume,         0 },
         { "saveState",      save_state,     0 },
@@ -299,6 +300,12 @@ duk_ret_t session_wrapper::load_state(duk_context* ctx)
 duk_ret_t session_wrapper::pause(duk_context* ctx)
 {
     common::get_pointer<libtorrent::session>(ctx)->pause();
+    return 0;
+}
+
+duk_ret_t session_wrapper::post_torrent_updates(duk_context* ctx)
+{
+    common::get_pointer<libtorrent::session>(ctx)->post_torrent_updates();
     return 0;
 }
 


### PR DESCRIPTION
Implemented seed goals for torrents (ref #82). You configure the default seed goal options in `hadouken.json` and then each added torrent copies these. This allows each torrent to individually alter its options.

**Features**
- Pause a torrent when reaching a specified seed ratio.
- Remove a torrent when reaching a specified seed ratio.

Only torrents which are finished (ie. all files selected for downloading are done) and *not* paused are subject to the seeding goals.