### PR TITLE
Building on Ubuntu.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 deps/
-
 docs/build
+src/version.cpp
+
+linux/build
 
 win32/bin
 win32/build
@@ -8,5 +10,3 @@ win32/chocolatey/tools/chocolateyInstall.ps1
 win32/libs
 win32/tools/Cake
 win32/wixobj
-
-src/version.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,9 +32,6 @@ if(WIN32)
     )
 
     include_directories(
-        ${CMAKE_SOURCE_DIR}/deps/cpp-netlib-0.11.1
-        ${CMAKE_SOURCE_DIR}/deps/libtorrent-rasterbar-1.0.5/include
-        ${CMAKE_SOURCE_DIR}/deps/libtorrent-rasterbar-1.0.5/ed25519/src
         ${CMAKE_SOURCE_DIR}/win32/libs/hadouken.boost/include
         ${CMAKE_SOURCE_DIR}/win32/libs/hadouken.openssl/win32/include
     )
@@ -48,14 +45,19 @@ if(WIN32)
     set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} /DEBUG /OPT:REF")
     set(CMAKE_EXE_LINKER_FLAGS_RELEASE    "${CMAKE_EXE_LINKER_FLAGS_RELEASE}    /DEBUG /OPT:REF")
 else()
-    set(LIBBOOST boost_system)
-    set(LIBTORRENT libtorrent-rasterbar.so)
+    set(LIBBOOST libboost_system.a libboost_log.a libboost_program_options.a libboost_filesystem.a libboost_thread.a)
+    set(LIBSSL ssl crypto)
     set(PTHREAD pthread)
 
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
     set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib/hadoukend")
 endif()
+
+include_directories(
+    ${CMAKE_SOURCE_DIR}/deps/cpp-netlib
+    ${CMAKE_SOURCE_DIR}/deps/libtorrent/include
+    ${CMAKE_SOURCE_DIR}/deps/libtorrent/ed25519/src
+)
 
 # add_definitions() doesn't seem to let you say wich build type to apply it to
 set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -DTORRENT_DEBUG")
@@ -98,7 +100,7 @@ include_directories(
     ${CMAKE_SOURCE_DIR}/include
 )
 
-set(ltdir ${CMAKE_SOURCE_DIR}/deps/libtorrent-rasterbar-1.0.5/src)
+set(ltdir ${CMAKE_SOURCE_DIR}/deps/libtorrent)
 
 # Get sources for libtorrent
 set(sources
@@ -220,25 +222,63 @@ set(ed25519_sources
 )
 
 foreach(s ${sources})
-    list(APPEND LIBTORRENT_SOURCES ${CMAKE_SOURCE_DIR}/deps/libtorrent-rasterbar-1.0.5/src/${s})
+    list(APPEND LIBTORRENT_SOURCES ${ltdir}/src/${s})
 endforeach(s)
 
 foreach(s ${kademlia_sources})
-    list(APPEND LIBTORRENT_SOURCES ${CMAKE_SOURCE_DIR}/deps/libtorrent-rasterbar-1.0.5/src/kademlia/${s})
+    list(APPEND LIBTORRENT_SOURCES ${ltdir}/src/kademlia/${s})
 endforeach(s)
 foreach(s ${ed25519_sources})
-    list(APPEND LIBTORRENT_SOURCES ${CMAKE_SOURCE_DIR}/deps/libtorrent-rasterbar-1.0.5/ed25519/src/${s})
+    list(APPEND LIBTORRENT_SOURCES ${ltdir}/ed25519/src/${s})
 endforeach(s)
 
-# Get sources for hadouken (except main.cpp)
-file(GLOB_RECURSE HADOUKEN_SOURCES ${CMAKE_SOURCE_DIR}/src/*.cpp)
-list(APPEND       HADOUKEN_SOURCES ${CMAKE_SOURCE_DIR}/src/scripting/duktape.c)
+
+set(HADOUKEN_SOURCES
+    src/application
+    src/main
+    src/version
+    src/hosting/console_host
+    src/http/connection_handler
+    src/http/http_server
+    src/scripting/duktape
+    src/scripting/script_host
+    src/scripting/modules/bencoding_module
+    src/scripting/modules/bittorrent_module
+    src/scripting/modules/core_module
+    src/scripting/modules/file_system_module
+    src/scripting/modules/http_module
+    src/scripting/modules/logger_module
+    src/scripting/modules/process_module
+    src/scripting/modules/bittorrent/add_torrent_params_wrapper
+    src/scripting/modules/bittorrent/alert_wrapper
+    src/scripting/modules/bittorrent/announce_entry_wrapper
+    src/scripting/modules/bittorrent/entry_wrapper
+    src/scripting/modules/bittorrent/error_code_wrapper
+    src/scripting/modules/bittorrent/feed_handle_wrapper
+    src/scripting/modules/bittorrent/feed_settings_wrapper
+    src/scripting/modules/bittorrent/feed_status_wrapper
+    src/scripting/modules/bittorrent/lazy_entry_wrapper
+    src/scripting/modules/bittorrent/peer_info_wrapper
+    src/scripting/modules/bittorrent/session_settings_wrapper
+    src/scripting/modules/bittorrent/session_wrapper
+    src/scripting/modules/bittorrent/torrent_creator_wrapper
+    src/scripting/modules/bittorrent/torrent_handle_wrapper
+    src/scripting/modules/bittorrent/torrent_info_wrapper
+    src/scripting/modules/bittorrent/torrent_status_wrapper
+)
+
+# Append platform-specific sources
+if(WIN32)
+    list(APPEND HADOUKEN_SOURCES src/platform_win32 src/hosting/service_host)
+else()
+    list(APPEND HADOUKEN_SOURCES src/platform_unix)
+endif(WIN32)
 
 set(CPP_NETLIB_SOURCES
-    ${CMAKE_SOURCE_DIR}/deps/cpp-netlib-0.11.1/libs/network/src/client
-    ${CMAKE_SOURCE_DIR}/deps/cpp-netlib-0.11.1/libs/network/src/server_request_parsers_impl
-    ${CMAKE_SOURCE_DIR}/deps/cpp-netlib-0.11.1/libs/network/src/uri/schemes
-    ${CMAKE_SOURCE_DIR}/deps/cpp-netlib-0.11.1/libs/network/src/uri/uri
+    ${CMAKE_SOURCE_DIR}/deps/cpp-netlib/libs/network/src/client
+    ${CMAKE_SOURCE_DIR}/deps/cpp-netlib/libs/network/src/server_request_parsers_impl
+    ${CMAKE_SOURCE_DIR}/deps/cpp-netlib/libs/network/src/uri/schemes
+    ${CMAKE_SOURCE_DIR}/deps/cpp-netlib/libs/network/src/uri/uri
 )
 
 add_executable(
@@ -255,5 +295,3 @@ target_link_libraries(
     ${LIBSSL}
     ${PTHREAD}
 )
-
-install(TARGETS hadouken  DESTINATION sbin)

--- a/docs/src/building/ubuntu.rst
+++ b/docs/src/building/ubuntu.rst
@@ -4,23 +4,25 @@ Building Hadouken on Ubuntu
 Overview
 --------
 
-This will guide you through the process of building Hadouken on Ubuntu
-using G++. *libtorrent* and *cpp-netlib* must be manually placed in the
-:file:`deps/` directory.
+This will guide you through the process of building Hadouken on Ubuntu.
+*libtorrent* and *cpp-netlib* must be placed in the :file:`deps/` directory.
+If you run the :file:`./bootstrap.sh` script, this will be taken care of.
 
 
-Prerequisites
+What you need
 -------------
 
 In order to successfully clone and build Hadouken you need the following
-applications installed,
+applications and libraries installed.
 
-* :code:`build-essential` - provides g++ and other required build tools.
-* :code:`cmake` - the build system Hadouken uses.
-* :code:`git` - to get the latest Hadouken sources.
-* :code:`libboost-system-dev` - required for Rasterbar-libtorrent.
-* :code:`libssl-dev` - for HTTPS and SSL functionality in both Hadouken and
-  Rasterbar-libtorrent.
+* :code:`g++-4.9`
+* :code:`cmake`
+* :code:`git`
+* :code:`libssl-dev`
+* :code:`libboost-1.58`
+
+.. note:: Hadouken will not compile with a `g++` version lower than 4.9 since
+          that is the version which shipped with C++14 support.
 
 
 Cloning the repository
@@ -33,21 +35,15 @@ Clone the Hadouken GitHub repository at https://github.com/hadouken/hadouken.
    $ git clone https://github.com/hadouken/hadouken
 
 
-Obtaining source dependencies
+Bootstrapping
 -----------------------------
 
-The following source dependencies should be downloaded and extracted to the
-:file:`deps/` directory.
+The repository contains a bootstrap script which will prepare your
+environment.
 
-* `libtorrent 1.0.5 <http://sourceforge.net/projects/libtorrent/files/libtorrent/libtorrent-rasterbar-1.0.5.tar.gz/download>`_
-* `cpp-netlib 0.11.1 <http://storage.googleapis.com/cpp-netlib-downloads/0.11.1/cpp-netlib-0.11.1-final.zip>`_
+.. code:: bash
 
-The :file:`deps/` directory should look like this,
-
-* deps/
-
-  * libtorrent-rasterbar-1.0.5/
-  * cpp-netlib-0.11.1/
+   $ ./linux/bootstrap.sh
 
 
 Running the build
@@ -57,7 +53,4 @@ By now you should have all you need to build Hadouken.
 
 .. code:: bash
 
-   $ mkdir cmake-build
-   $ cd cmake-build/
-   $ cmake ..
-   $ make
+   $ ./linux/build.sh

--- a/docs/src/building/windows.rst
+++ b/docs/src/building/windows.rst
@@ -44,8 +44,8 @@ The :file:`deps/` directory should look like this,
 
 * deps/
 
-  * libtorrent-rasterbar-1.0.5/
-  * cpp-netlib-0.11.1/
+  * libtorrent/
+  * cpp-netlib/
 
 
 Running the build

--- a/linux/bootstrap.sh
+++ b/linux/bootstrap.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Script variables
+DEPS_DIR="./deps" # where should we put our dependencies.
+
+LT_REPO="https://github.com/arvidn/libtorrent"
+LT_DIR="libtorrent"
+LT_TAG="libtorrent-1_0_5"
+
+CPPNL_URL="http://storage.googleapis.com/cpp-netlib-downloads/0.11.1/cpp-netlib-0.11.1-final.zip"
+CPPNL_DIR_ORIG="cpp-netlib-0.11.1-final"
+CPPNL_DIR_NEW="cpp-netlib"
+CPPNL_FILE="cpp-netlib.zip"
+
+# Create DEPS_DIR if it doesn't exist
+mkdir -p $DEPS_DIR
+
+# Clone libtorrent to DEPS_DIR
+if [[ ! -d "$DEPS_DIR/$LT_DIR" ]]; then
+    ( cd $DEPS_DIR ; git clone $LT_REPO )
+fi
+
+# Checkout the correct libtorrent tag
+( cd $DEPS_DIR ; cd $LT_DIR ; git checkout $LT_TAG )
+
+# Download cpp-netlib
+if [[ ! -f "$DEPS_DIR/$CPPNL_FILE" ]]; then
+    wget $CPPNL_URL -O "$DEPS_DIR/$CPPNL_FILE"
+fi
+
+# unzip cpp netlib
+if [[ ! -d "$DEPS_DIR/$CPPNL_DIR_NEW" ]]; then
+    ( cd $DEPS_DIR ; unzip $CPPNL_FILE ; mv $CPPNL_DIR_ORIG $CPPNL_DIR_NEW )
+fi

--- a/linux/build.sh
+++ b/linux/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cd "$(dirname "$0")"
+
+( mkdir -p build ; cd build ; cmake ../../ ; make )

--- a/src/platform_unix.cpp
+++ b/src/platform_unix.cpp
@@ -1,20 +1,39 @@
 #ifdef __unix__
 
-#include <Hadouken/Platform.hpp>
-#include <Poco/Path.h>
+#include <boost/filesystem.hpp>
+#include <hadouken/platform.hpp>
+#include <limits.h>
+#include <unistd.h>
 
-using namespace Hadouken;
+using namespace hadouken;
+namespace fs = boost::filesystem;
 
-Poco::Path Platform::getApplicationDataPath()
+void platform::init()
 {
-    // TODO: do something useful.
-    return Poco::Path("/etc/hadouken/");
 }
 
-Poco::Path Platform::getApplicationPath()
+fs::path platform::data_path()
 {
     // TODO: do something useful.
-    return Poco::Path();
+    return "/etc/hadouken/";
+}
+
+fs::path platform::application_path()
+{
+    char result[PATH_MAX];
+    ssize_t count = readlink("/proc/self/exe", result, PATH_MAX);
+    std::string p(result, (count > 0) ? count : 0);
+
+    return fs::path(p).parent_path();
+}
+
+fs::path platform::get_current_directory()
+{
+    return fs::initial_path();
+}
+
+int platform::launch_process(std::string executable, std::vector<std::string> args)
+{
 }
 
 #endif

--- a/src/platform_win32.cpp
+++ b/src/platform_win32.cpp
@@ -1,5 +1,3 @@
-#ifdef WIN32
-
 #include <hadouken/platform.hpp>
 
 #include <atlstr.h>
@@ -211,5 +209,3 @@ int platform::launch_process(std::string executable, std::vector<std::string> ar
 
     return exitCode;
 }
-
-#endif

--- a/src/scripting/duktape.c
+++ b/src/scripting/duktape.c
@@ -24663,10 +24663,6 @@ DUK_LOCAL void duk__bi_global_resolve_module_id(duk_context *ctx, const char *re
 			}
 			DUK_DD(DUK_DDPRINT("resolve error: term begins with '.' but is not '.' or '..' (not allowed now)"));
 			goto resolve_error;
-		} else if (DUK_UNLIKELY(c == '/')) {
-			/* e.g. require('/foo'), empty terms not allowed */
-			DUK_DD(DUK_DDPRINT("resolve error: empty term (not allowed now)"));
-			goto resolve_error;
 		} else {
 			for (;;) {
 				/* Copy term name until end or '/'. */

--- a/src/scripting/modules/bittorrent/session_settings_wrapper.cpp
+++ b/src/scripting/modules/bittorrent/session_settings_wrapper.cpp
@@ -9,14 +9,14 @@
     duk_ret_t session_settings_wrapper::get_##prop(duk_context* ctx) \
         { \
         libtorrent::session_settings* ss = common::get_pointer<libtorrent::session_settings>(ctx); \
-        duk_push_string(ctx, ss->##prop.c_str()); \
+        duk_push_string(ctx, ss->prop.c_str()); \
         return 1; \
         } \
     \
     duk_ret_t session_settings_wrapper::set_##prop(duk_context* ctx) \
         { \
         libtorrent::session_settings* ss = common::get_pointer<libtorrent::session_settings>(ctx); \
-        ss->##prop = duk_require_string(ctx, 0); \
+        ss->prop = duk_require_string(ctx, 0); \
         return 0; \
         }
 
@@ -24,14 +24,14 @@
     duk_ret_t session_settings_wrapper::get_##prop(duk_context* ctx) \
         { \
         libtorrent::session_settings* ss = common::get_pointer<libtorrent::session_settings>(ctx); \
-        duk_push_int(ctx, ss->##prop); \
+        duk_push_int(ctx, ss->prop); \
         return 1; \
         } \
     \
     duk_ret_t session_settings_wrapper::set_##prop(duk_context* ctx) \
         { \
         libtorrent::session_settings* ss = common::get_pointer<libtorrent::session_settings>(ctx); \
-        ss->##prop = duk_require_int(ctx, 0); \
+        ss->prop = duk_require_int(ctx, 0); \
         return 0; \
         }
 

--- a/src/scripting/modules/bittorrent/session_wrapper.cpp
+++ b/src/scripting/modules/bittorrent/session_wrapper.cpp
@@ -174,7 +174,10 @@ duk_ret_t session_wrapper::get_feeds(duk_context* ctx)
 duk_ret_t session_wrapper::get_settings(duk_context* ctx)
 {
     libtorrent::session* sess = common::get_pointer<libtorrent::session>(ctx);
-    session_settings_wrapper::initialize(ctx, sess->settings());
+    
+    libtorrent::session_settings settings = sess->settings();
+    session_settings_wrapper::initialize(ctx, settings);
+    
     return 1;
 }
 

--- a/src/scripting/modules/common.hpp
+++ b/src/scripting/modules/common.hpp
@@ -1,6 +1,7 @@
 #ifndef HADOUKEN_SCRIPTING_MODULES_COMMON_HPP
 #define HADOUKEN_SCRIPTING_MODULES_COMMON_HPP
 
+#include <typeinfo>
 #include "../duktape.h"
 
 #define DUK_READONLY_PROPERTY(ctx, index, name, func) \


### PR DESCRIPTION
Tools and software used,

- Ubuntu 15.04
- GCC 4.9
- Boost 1.58

**Todo**
- [x] Remove wild card source file mapping and specify source files manually. We can then include only the platform specific files required instead of having (for example) `platform_win32.cpp` included in Linux builds.
- [x] Fix the Duktape `require` issue.