### PR TITLE
Auto-label plugin.

### DIFF
--- a/docs/src/configuration/autolabel.rst
+++ b/docs/src/configuration/autolabel.rst
@@ -1,0 +1,82 @@
+
+Configuring AutoLabel
+=====================
+
+Overview
+--------
+
+The AutoLabel extension can automatically set a label on added torrents so you
+don't have to. It matches a regular expression against either the torrent name
+or any of the torrent trackers and then sets the configured label.
+
+
+Enabling AutoLabel
+----------------
+
+.. code:: javascript
+
+  {
+    "extensions":
+    {
+      "autolabel":
+      {
+        "enabled": true
+      }
+    }
+  }
+
+
+Matching a torrent
+------------------
+
+The simplest way to auto label a torrent is to match the name against a regular
+expression. This example matches any torrents starting with `debian` and labels
+them as *debian*.
+
+.. code:: javascript
+
+  {
+    "extensions":
+    {
+      "autolabel":
+      {
+        "enabled": true,
+        "rules":
+        [
+          {
+            "field": "name",
+            "pattern": "^debian.*$",
+            "label": "debian"
+          }
+        ]
+      }
+    }
+  }
+
+
+Matching trackers
+-----------------
+
+It is equally easy to match against any of the trackers in the torrent file.
+This will label a torrent as *debian* if one of the trackers starts with
+`http://bttracker.debian.org`.
+
+.. code:: javascript
+
+  {
+    "extensions":
+    {
+      "autolabel":
+      {
+        "enabled": true,
+        "rules":
+        [
+          {
+            "field": "tracker",
+            "pattern": "^http://bttracker\\.debian\\.org.*$",
+            "label": "debian"
+          }
+        ]
+      }
+    }
+  }

--- a/js/plugins/autolabel.js
+++ b/js/plugins/autolabel.js
@@ -1,0 +1,77 @@
+var bt      = require("bittorrent");
+var config  = require("config");
+var logger  = require("logger").get("plugins.autolabel");
+var session = bt.session;
+
+function isMatch(torrent, field, pattern) {
+    switch(field) {
+        case "name":
+            var status = torrent.getStatus();
+            return pattern.test(status.name);
+
+        case "tracker":
+            var trackers = torrent.getTrackers();
+            for(var i = 0; i < trackers.length; i++) {
+                if(pattern.test(trackers[i].url)) {
+                    return true;
+                }
+            }
+            break;
+        default:
+            return false;
+    }
+
+    return false;
+}
+
+function torrentAdded(rules, torrent) {
+    if(!torrent.isValid) {
+        return;
+    }
+
+    var existingLabel = (torrent.metadata("label") || "");
+
+    if(existingLabel || existingLabel !== "") {
+        // Do not label torrents with an existing label.
+        return;
+    }
+
+    for(var i = 0; i < rules.length; i++) {
+        var rule = rules[i];
+
+        if(!rule.field || !rule.pattern || !rule.label) {
+            logger.warn("Found invalid AutoLabel rule.");
+            continue;
+        }
+
+        if(isMatch(torrent, rule.field, new RegExp(rule.pattern))) {
+            logger.info("Updated label on '" +
+                        torrent.getStatus().name +
+                        "' to '" +
+                        rule.label +
+                        "'.");
+
+            torrent.metadata("label", rule.label);
+            break;
+        }
+    }
+}
+
+function load() {
+    var enabled = config.getBoolean("extensions.autolabel.enabled");
+    
+    if(!enabled) {
+        return;
+    }
+
+    var currentTick = 0;
+    var rules       = config.get("extensions.autolabel.rules");
+
+    session.on("torrent.add", function(args) {
+        torrentAdded(rules, args.torrent);
+    });
+
+    logger.info("AutoLabel loaded with " + rules.length + " rules.");
+}
+
+exports.load = load;


### PR DESCRIPTION
A plugin which provides basic auto-labelling features. It will match a torrent name or any of the torrent trackers against a regex filter and set the configured label on the torrent if it matches.

**Configuration example**

```javascript
"extensions": {
  "autolabel": {
    "enabled": true,
    "rules": [
      {
        "field": "name",
        "pattern": "^debian-.*$",
        "label": "Linux ISOs"
      }
    ]
  }
},
```

**Todo**
- [x] Match against trackers.
- [x] Update documentation.

ref #75 