### PR TITLE
Compiling with C++11.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,14 +12,14 @@ addons:
     sources:
     - ubuntu-toolchain-r-test
     packages:
-    - g++-4.9
+    - g++-4.8
 
 before_install:
 - bash linux/install-boost.sh
 
 before_script:
-- export CC=/usr/bin/gcc-4.9
-- export CXX=/usr/bin/g++-4.9
+- export CC=/usr/bin/gcc-4.8
+- export CXX=/usr/bin/g++-4.8
 - export CPATH=$HOME/boost/include
 - export LIBRARY_PATH=$HOME/boost/lib
 - git submodule update --init --recursive

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ else()
     set(LIBSSL ssl crypto)
     set(PTHREAD pthread)
 
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
     
     if(DEFINED ENV{TRAVIS})
         # Disable deprecated warnings (for auto_ptr mainly) on travis

--- a/docs/src/building/ubuntu.rst
+++ b/docs/src/building/ubuntu.rst
@@ -4,8 +4,9 @@ Building Hadouken on Ubuntu
 Overview
 --------
 
-This will guide you through the process of building Hadouken on Ubuntu.
-The depenencies *libtorrent* and *cpp-netlib* exists as Git submodules.
+This will guide you through the process of building Hadouken on Ubuntu 14.04.2
+(Trusty Tahr). The depenencies *libtorrent* and *cpp-netlib* exists as Git
+submodules.
 
 
 What you need
@@ -14,14 +15,10 @@ What you need
 In order to successfully clone and build Hadouken you need the following
 applications and libraries installed.
 
-* :code:`g++-4.9`
 * :code:`cmake`
 * :code:`git`
 * :code:`libssl-dev`
 * :code:`libboost-1.58`
-
-.. note:: Hadouken will not compile with a `GCC` version lower than 4.9 since
-          that is the version which shipped with C++14 support.
 
 
 Cloning the repository

--- a/linux/install-boost.sh
+++ b/linux/install-boost.sh
@@ -4,8 +4,8 @@ set -e
 if [ ! -d "$HOME/boost/lib" ]; then
   wget http://downloads.sourceforge.net/project/boost/boost/1.58.0/boost_1_58_0.tar.gz
   tar -xzvf boost_1_58_0.tar.gz > /dev/null
-  echo "using gcc : 4.9 : /usr/bin/g++-4.9 ; " >> $HOME/user-config.jam
-  cd boost_1_58_0 && ./bootstrap.sh toolset=gcc-4.9 --prefix=$HOME/boost --with-libraries=system,log,filesystem,program_options,thread && ./b2 toolset=gcc-4.9 install && ./b2 install >> /dev/null
+  echo "using gcc : 4.8 : /usr/bin/g++-4.8 ; " >> $HOME/user-config.jam
+  cd boost_1_58_0 && ./bootstrap.sh toolset=gcc-4.8 --prefix=$HOME/boost --with-libraries=system,log,filesystem,program_options,thread && ./b2 toolset=gcc-4.8 install >> /dev/null
 else
   echo "Using cached directory."
 fi

--- a/src/application.cpp
+++ b/src/application.cpp
@@ -17,14 +17,14 @@ application::application(boost::shared_ptr<boost::asio::io_service> io, const pt
     : io_(io),
     config_(config)
 {
-    script_host_ = std::make_unique<hadouken::scripting::script_host>(*this);
+    script_host_ = std::unique_ptr<hadouken::scripting::script_host>(new hadouken::scripting::script_host(*this));
     
-    http_ = std::make_unique<hadouken::http::http_server>(io, config);
+    http_ = std::unique_ptr<hadouken::http::http_server>(new hadouken::http::http_server(io, config));
     http_->set_auth_callback(boost::bind(&application::is_authenticated, this, _1));
     http_->set_rpc_callback(boost::bind(&application::rpc, this, _1));
 
     libtorrent::fingerprint fingerprint("LT", LIBTORRENT_VERSION_MAJOR, LIBTORRENT_VERSION_MINOR, 0, 0);
-    session_ = std::make_unique<libtorrent::session>(fingerprint, 0);
+    session_ = std::unique_ptr<libtorrent::session>(new libtorrent::session(fingerprint, 0));
 }
 
 application::~application()

--- a/src/http/http_server.cpp
+++ b/src/http/http_server.cpp
@@ -37,7 +37,8 @@ http_server::http_server(boost::shared_ptr<boost::asio::io_service> io, const bo
         }
     }
 
-    instance_ = std::make_unique<http_server_t>(opts.address(address).port(std::to_string(port)).io_service(io));
+    instance_ = std::unique_ptr<http_server_t>(
+        new http_server_t(opts.address(address).port(std::to_string(port)).io_service(io)));
 
     // register request handlers
     request_handlers_["^\/api[\/]?$"] = std::make_shared<api_request_handler>([this](std::string f) {


### PR DESCRIPTION
Downgrading GCC to v4.8 and compiling with with C++11 instead of C++14.

Ubuntu 14.04.2 LTS (Trusty Tahr) has GCC-4.8 in its stable repo, so no need to upgrade to GCC-4.9 anymore.