### PR TITLE
Label-support in AutoAdd and AutoMove.

### DIFF
--- a/docs/src/configuration/autoadd.rst
+++ b/docs/src/configuration/autoadd.rst
@@ -107,3 +107,26 @@ two tags to each torrent it finds.
       }
     }
   }
+
+
+Adding a label
+--------------
+
+.. code:: javascript
+
+  {
+    "extensions":
+    {
+      "autoadd":
+      {
+        "enabled": true,
+        "folders":
+        [
+          {
+            "path": "C:/Torrents",
+            "label": "my-awesome-label"
+          }
+        ]
+      }
+    }
+  }

--- a/docs/src/configuration/automove.rst
+++ b/docs/src/configuration/automove.rst
@@ -90,3 +90,30 @@ matching and moving rules.
       }
     }
   }
+
+
+Label-based moving
+------------------
+
+The label filter will match a torrent against a label. If the torrent has the
+provided label, it will be moved to the path.
+
+.. code:: javascript
+
+  {
+    "extensions":
+    {
+      "automove":
+      {
+        "enabled": true,
+        "rules":
+        [
+          {
+            "path": "C:/Downloads/Debian ISOs",
+            "filter": "label",
+            "data": "my-awesome-label"
+          }
+        ]
+      }
+    }
+  }

--- a/docs/src/configuration/rss.rst
+++ b/docs/src/configuration/rss.rst
@@ -20,8 +20,10 @@ specified feed.
   {
     "feeds":
     [
-      "url":    "http://some-rss.net/feed",
-      "filter": "*"
+      {
+        "url":    "http://some-rss.net/feed",
+        "filter": "*"
+      }
     ]
   }
 
@@ -40,8 +42,10 @@ The exclude filter is optional.
   {
     "feeds":
     [
-      "url":    "http://some-rss.net/feed",
-      "filter": [ "regex", "720p", "NUKED" ]
+      {
+        "url":    "http://some-rss.net/feed",
+        "filter": [ "regex", "720p", "NUKED" ]
+      }
     ]
   }
 
@@ -60,10 +64,12 @@ Save path
   {
     "feeds":
     [
-      "url": "http://some-rss.net/feed",
-      "options":
       {
-        "savePath": "C:/Downloads/from-some-rss"
+        "url": "http://some-rss.net/feed",
+        "options":
+        {
+          "savePath": "C:/Downloads/from-some-rss"
+        }
       }
     ]
   }
@@ -79,8 +85,10 @@ start. The `ttl` value indicates the poll rate in minutes.
   {
     "feeds":
     [
-      "url": "http://some-rss.net/feed",
-      "ttl": 2
+      {
+        "url": "http://some-rss.net/feed",
+        "ttl": 2
+      }
     ]
   }
 
@@ -96,10 +104,12 @@ debug regular expression filters.
   {
     "feeds":
     [
-      "url": "http://some-rss.net/feed",
-      "options":
       {
-        "dryRun": true
+        "url": "http://some-rss.net/feed",
+        "options":
+        {
+          "dryRun": true
+        }
       }
     ]
   }

--- a/js/plugins/autoadd.js
+++ b/js/plugins/autoadd.js
@@ -29,6 +29,10 @@ function checkFiles(folder, files) {
                 p.savePath = folder.savePath;
             }
 
+            if(folder.label) {
+                meta.label = folder.label;
+            }
+
             if(folder.tags) {
                 meta.tags = folder.tags;
             }

--- a/js/plugins/automove.js
+++ b/js/plugins/automove.js
@@ -41,6 +41,17 @@ TagsFilter.prototype.isMatch = function(torrent) {
     return true;
 }
 
+function LabelFilter(label) {
+    this._label = label;
+}
+
+LabelFilter.prototype.isMatch = function(torrent) {
+    var label = torrent.metadata("label");
+    if(!label) { return false; }
+
+    return (this._label === label);
+}
+
 function getRules() {
     var values  = config.get("extensions.automove.rules");
     var result = [];
@@ -56,6 +67,8 @@ function getRules() {
             result.push(new Rule(path, new PatternFilter(new RegExp(pattern), field)));
         } else if(filter === "tags") {
             result.push(new Rule(path, new TagsFilter(values[i].data)));
+        } else if(filter === "label") {
+            result.push(new Rule(path, new LabelFilter(values[i].data)));
         }
     }
 


### PR DESCRIPTION
This implements label-support in AutoAdd and AutoMove. Also fixes a typo in the RSS docs (ref #175).