### PR TITLE
Force rechecking an unmanaged, paused torrent.

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -98,6 +98,17 @@ session.on("torrent.added", function(e) {
     saveTorrent(e.torrent);
 });
 
+session.on("torrent.checked", function(e) {
+    var torrent = e.torrent;
+
+    if(torrent.metadata("_pauseAfterRecheck")) {
+        torrent.pause();
+        torrent.metadata("_pauseAfterRecheck", false);
+    }
+
+    logger.debug("Torrent '" + e.torrent.infoHash + "' hash checked.");
+});
+
 session.on("torrent.hashUpdated", function(e) {
     /*
     On migrating metadata

--- a/js/rpc/webui_perform.js
+++ b/js/rpc/webui_perform.js
@@ -29,6 +29,21 @@ function perform(action, torrent) {
             break;
 
         case "recheck":
+            var status = torrent.getStatus();
+
+            if(!status.hasMetadata) {
+                return;
+            }
+
+            // If the torrent is paused and *not* automanaged,
+            // set a flag to pause if after recheck and then
+            // resume it so the recheck can start.
+
+            if(status.isPaused && !torrent.autoManaged) {
+                torrent.metadata("_pauseAfterRecheck", true);
+                torrent.resume();
+            }
+
             torrent.forceRecheck();
             break;
 


### PR DESCRIPTION
Force rechecking an unmanaged, paused torrent will now do the recheck and then return it to a paused state.

ref #177 