### PR TITLE
Fix an off-by-1 error in the directory selection.

### DIFF
--- a/js/rpc/webui_addTorrent.js
+++ b/js/rpc/webui_addTorrent.js
@@ -47,7 +47,7 @@ exports.rpc = {
                 var dirs = config.get("bittorrent.downloadDirectories") || [];
 
                 if(idx < dirs.length) {
-                    p.savePath = dirs[idx];
+                    p.savePath = dirs[idx - 1];
                 }
             }
         }


### PR DESCRIPTION
The default directory is already idx 0, but the first of the optional download directories is indexed at 0 too, so if idx 1 is returned then the user selected dirs[0], not dirs[1].
