### PR TITLE
Fix to allow selecting the last item in the download directories list

### DIFF
--- a/js/rpc/webui_addTorrent.js
+++ b/js/rpc/webui_addTorrent.js
@@ -46,7 +46,7 @@ exports.rpc = {
             if(!isNaN(idx) && idx > 0) {
                 var dirs = config.get("bittorrent.downloadDirectories") || [];
 
-                if(idx < dirs.length) {
+                if(idx <= dirs.length) {
                     p.savePath = dirs[idx - 1];
                 }
             }


### PR DESCRIPTION
The idx value ranges from 0 to dirs.length, with an idx value greater than zero always corresponding to dirs[idx - 1], therefore the input check needs to support an input of dirs.length.

Without this the program uses the default save path whenever the user selects the last save path in their list.
