### PR TITLE
Keep after auto add

### DIFF
--- a/docs/src/configuration/autoadd.rst
+++ b/docs/src/configuration/autoadd.rst
@@ -130,3 +130,30 @@ Adding a label
       }
     }
   }
+
+
+Keeping .torrent files after adding
+-----------------------------------
+
+When using a utility such as Ketarin or other automated software downloading
+utility, it may be more beneficial to keep the .torrent file in your autoadd
+path to prevent your software re-downloading the .torrent with every run.
+
+.. code:: javascript
+
+  {
+    "extensions":
+    {
+      "autoadd":
+      {
+        "enabled": true,
+        "folders":
+        [
+          {
+            "path": "C:/Torrents",
+            "keep": true
+          }
+        ]
+      }
+    }
+  }

--- a/js/plugins/autoadd.js
+++ b/js/plugins/autoadd.js
@@ -41,7 +41,9 @@ function checkFiles(folder, files) {
 
             p.metadata = meta;
             session.addTorrent(p);
-            fs.deleteFile(file);
+            if(!folder.keep) {
+                fs.deleteFile(file);
+            }
         }
     }
 }


### PR DESCRIPTION
Instead of deleting files after autoadd plugin has imported them, keep them for cases when the original .torrent files would just keep getting downloaded by an external process such as Ketarin or a directory sync.
