### PR TITLE
[WIP] Tentative compilation support for OSX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ elseif(APPLE)
     include_directories(/usr/local/include)
     link_directories(/usr/local/lib)
 
-    find_package(Boost REQUIRED COMPONENTS system log program_options filesystem log thread)
+    find_package(Boost REQUIRED COMPONENTS system program_options filesystem log thread)
 
     set(LIBSSL ssl crypto)
     set(PTHREAD pthread)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,10 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 # Windows DLLs are "runtime" for CMake. Output them to "bin" like the Visual Studio projects do.
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
+# Options used for OSX build
+option(Boost_USE_STATIC_LIBS "Static linking to boost libraries" ON)
+option(Boost_USE_STATIC_RUNTIME "Static runtime" ON)
+
 if(WIN32)
     set(LIBSSL libeay32.lib ssleay32.lib)
     set(LIBEXTRAS iphlpapi.lib dbghelp.lib shlwapi.lib)
@@ -47,6 +51,26 @@ if(WIN32)
     # Make sure release builds have pdb files.
     set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} /DEBUG /OPT:REF")
     set(CMAKE_EXE_LINKER_FLAGS_RELEASE    "${CMAKE_EXE_LINKER_FLAGS_RELEASE}    /DEBUG /OPT:REF")
+elseif(APPLE)
+    
+    # This is to find some libraries installed via brew
+    include_directories(/usr/local/include)
+    link_directories(/usr/local/lib)
+
+    find_package(Boost REQUIRED COMPONENTS system log program_options filesystem log thread)
+
+    set(LIBSSL ssl crypto)
+    set(PTHREAD pthread)
+
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+
+    include_directories(${CMAKE_SOURCE_DIR}/deps/libtorrent/include) 
+
+    include_directories(${Boost_INCLUDE_DIRS})
+    link_directories(${Boost_LIBRARY_DIRS})
+
+    set(LIBBOOST ${Boost_LIBRARIES})
+
 else()
     set(LIBBOOST libboost_system.a libboost_log.a libboost_program_options.a libboost_filesystem.a libboost_thread.a)
     set(LIBEXTRAS rt)
@@ -229,7 +253,7 @@ set(ed25519_sources
     verify
 )
 
-if(WIN32)
+if(WIN32 OR APPLE)
     foreach(s ${sources})
         list(APPEND LIBTORRENT_SOURCES ${ltdir}/src/${s})
     endforeach(s)
@@ -240,7 +264,7 @@ if(WIN32)
     foreach(s ${ed25519_sources})
         list(APPEND LIBTORRENT_SOURCES ${ltdir}/ed25519/src/${s})
     endforeach(s)
-endif(WIN32)
+endif(WIN32 OR APPLE)
 
 
 set(HADOUKEN_SOURCES
@@ -282,6 +306,8 @@ set(HADOUKEN_SOURCES
 # Append platform-specific sources
 if(WIN32)
     list(APPEND HADOUKEN_SOURCES src/platform_win32 src/hosting/service_host)
+elseif(APPLE)
+    list(APPEND HADOUKEN_SOURCES src/platform_osx)
 else()
     list(APPEND HADOUKEN_SOURCES src/platform_unix)
 endif(WIN32)

--- a/src/platform_osx.cpp
+++ b/src/platform_osx.cpp
@@ -1,0 +1,52 @@
+#ifdef __APPLE__
+
+#include <boost/filesystem.hpp>
+#include <hadouken/platform.hpp>
+
+#include <cstdlib>
+#include <mach-o/dyld.h>
+
+using namespace hadouken;
+namespace fs = boost::filesystem;
+
+void platform::init() {}
+
+fs::path platform::data_path() 
+{
+    // TODO: find folders using URLsForDirectory
+
+    char *home_path = getenv("HOME");
+
+    if(home_path != nullptr) {
+        std::string p(home_path);
+        p += "/Downloads";
+        return fs::path(p);
+    }
+
+    return "";
+}
+
+fs::path platform::application_path() 
+{
+    char path[2048];
+    uint32_t size = sizeof(path);
+
+    if (_NSGetExecutablePath(path, &size) == 0) {
+        return fs::path(path).parent_path();
+    }
+
+    return "";
+}
+
+fs::path platform::get_current_directory() 
+{ 
+    return fs::initial_path(); 
+}
+
+int platform::launch_process(std::string executable,
+                             std::vector<std::string> args) 
+{
+    return 0;
+}
+
+#endif

--- a/src/platform_osx.cpp
+++ b/src/platform_osx.cpp
@@ -17,7 +17,8 @@ fs::path platform::data_path()
 
     char *home_path = getenv("HOME");
 
-    if(home_path != nullptr) {
+    if(home_path != nullptr) 
+    {
         std::string p(home_path);
         p += "/Downloads";
         return fs::path(p);
@@ -31,7 +32,8 @@ fs::path platform::application_path()
     char path[2048];
     uint32_t size = sizeof(path);
 
-    if (_NSGetExecutablePath(path, &size) == 0) {
+    if (_NSGetExecutablePath(path, &size) == 0) 
+    {
         return fs::path(path).parent_path();
     }
 


### PR DESCRIPTION
Now cmake script uses find_package to find boost libraries …

Now cmake script accepts -DBOOST_ROOT parameter to specify custom boost installations

It should compile on OSX:

```
git submodule update --init
mkdir build
cd build
cmake .. -DBOOST_ROOT=<path to custom boost installation>
make -j 8
```

the binary is going to be generated in the bin/ subfolder
webui.zip and js folder needs to be copied in the same folder as the resulting binary

there are still some warning regarding to symbol visibility linking Boost Log.

note that most of the changes done to CMakeFile.txt can be easily used for linux.
