### PR TITLE
Print available command-line options when passing -h or --help

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -35,11 +35,12 @@ po::variables_map load_options(int argc,char *argv[])
     po::store(po::parse_command_line(argc, argv, desc), vm);
     po::notify(vm);
     
+    // Print Help and exit if we get --help or -h on the command-line.
     if (vm.count("help")) {
         std::cout << desc << "\n";
-        return 1;
+        exit (EXIT_SUCCESS);
     }
-    
+
     return vm;
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -36,7 +36,7 @@ po::variables_map load_options(int argc,char *argv[])
     po::notify(vm);
     
     if (vm.count("help")) {
-        cout << desc << "\n";
+        std::cout << desc << "\n";
         return 1;
     }
     

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,6 +22,7 @@ po::variables_map load_options(int argc,char *argv[])
 {
     po::options_description desc("Allowed options");
     desc.add_options()
+        ("help,h", "Display available commandline options")
         ("config", po::value<std::string>(), "Set path to a JSON configuration file. The default is %appdir%/hadouken.json")
         ("daemon", "Start Hadouken in daemon/service mode.")
 #ifdef WIN32
@@ -33,7 +34,12 @@ po::variables_map load_options(int argc,char *argv[])
     po::variables_map vm;
     po::store(po::parse_command_line(argc, argv, desc), vm);
     po::notify(vm);
-
+    
+    if (vm.count("help")) {
+        cout << desc << "\n";
+        return 1;
+    }
+    
     return vm;
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -36,7 +36,8 @@ po::variables_map load_options(int argc,char *argv[])
     po::notify(vm);
     
     // Print Help and exit if we get --help or -h on the command-line.
-    if (vm.count("help")) {
+    if (vm.count("help"))
+    {
         std::cout << desc << "\n";
         exit (EXIT_SUCCESS);
     }


### PR DESCRIPTION
Implements half of #213.

Builds successfully on Ubuntu 14.04.
I do not have a windows machine to test on but there is no reason for it to fail on windows.

P.S. I am not a C++ dev so if I did a bad thing let me know.
