### PR TITLE
Fix seed ratio by removing seedOverride check

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -1,4 +1,4 @@
-﻿var bt       = require("bittorrent");
+var bt       = require("bittorrent");
 var benc     = require("benc");
 var config   = require("config");
 var fs       = require("fs");
@@ -81,7 +81,7 @@ session.on("torrent.add", function(e) {
 
         metadata["options"] = options;
 
-        logger.debug("Torrent '' assigned Seed Ratio: " + options.seedRatio + "%, Seed Time: " + options.seedTime + "minutes , Seed Action: " + options.seedAction);
+        logger.debug("Torrent '" + e.torrent.infoHash + "' assigned Seed Ratio: " + options.seedRatio + "%, Seed Time: " + options.seedTime + " seconds , Seed Action: " + options.seedAction);
     }
 
     var keys = Object.keys(metadata);
@@ -151,7 +151,7 @@ session.on("torrent.stateUpdate", function(e) {
         if(status.ratio >= parseFloat(goalRatio)
             || (goalTime > 0 && status.seedingTime > goalTime)) {
 
-            logger.info("Torrent '" + status.name + "' reached its seed goal of " + (status.ratio >= parseFloat(goalRatio) ? (goalRatio + "%") : (goalTime + "minutes")));
+            logger.info("Torrent '" + status.name + "' reached its seed goal of " + (status.ratio >= parseFloat(goalRatio) ? (goalRatio + "%") : (goalTime + " seconds")));
 
             var action = (options.seedAction || "pause");
 

--- a/js/core.js
+++ b/js/core.js
@@ -1,4 +1,4 @@
-var bt       = require("bittorrent");
+﻿var bt       = require("bittorrent");
 var benc     = require("benc");
 var config   = require("config");
 var fs       = require("fs");
@@ -80,6 +80,8 @@ session.on("torrent.add", function(e) {
         };
 
         metadata["options"] = options;
+
+        logger.debug("Torrent '' assigned Seed Ratio: " + options.seedRatio + "%, Seed Time: " + options.seedTime + "minutes , Seed Action: " + options.seedAction);
     }
 
     var keys = Object.keys(metadata);
@@ -143,13 +145,13 @@ session.on("torrent.stateUpdate", function(e) {
         var torrent = status.torrent;
         var options = torrent.metadata("options") || {};
 
-        var goalRatio = options.seedOverride ? (options.seedRatio || 2.0) : 2.0;
-        var goalTime  = options.seedOverride ? (options.goalTime  ||   0) :   0;
+        var goalRatio = options.seedRatio || 2.0;
+        var goalTime  = options.goalTime || 0;
 
         if(status.ratio >= parseFloat(goalRatio)
             || (goalTime > 0 && status.seedingTime > goalTime)) {
 
-            logger.info("Torrent " + status.name + " reached its seed goal.");
+            logger.info("Torrent '" + status.name + "' reached its seed goal of " + (status.ratio >= parseFloat(goalRatio) ? (goalRatio + "%") : (goalTime + "minutes")));
 
             var action = (options.seedAction || "pause");
 


### PR DESCRIPTION
When a torrent state is changed, the seed values are read from the
per-torrent metadata, if and only if a"seedOverride" option is also set.
If it is not set, the default values are used. There is no way to
actually set this option, however, which means the default values are
always used regardless of what is specified in the config file.

This change removes the seedOverride check, which allows the config
values to actually take effect.
