### PR TITLE
Support non-ANSII file paths from plugins

### DIFF
--- a/js/plugins/autoadd.js
+++ b/js/plugins/autoadd.js
@@ -21,28 +21,33 @@ function checkFiles(folder, files) {
 
         if(pattern.test(file)) {
             var buffer = fs.readBuffer(file);
-            var p      = bt.AddTorrentParams.getDefault();
-            var meta   = {};
-            p.torrent  = new bt.TorrentInfo(buffer);
+            if(typeof buffer != "undefined") {
+                var p      = bt.AddTorrentParams.getDefault();
+                var meta   = {};
+                p.torrent  = new bt.TorrentInfo(buffer);
 
-            if(folder.savePath) {
-                p.savePath = folder.savePath;
+                if(folder.savePath) {
+                    p.savePath = folder.savePath;
+                }
+
+                if(folder.label) {
+                    meta.label = folder.label;
+                }
+
+                if(folder.tags) {
+                    meta.tags = folder.tags;
+                }
+
+                logger.info("(AUTOADD) Adding torrent " + p.torrent.name + " from file " + file);
+
+                p.metadata = meta;
+                session.addTorrent(p);
+                if(!folder.keep) {
+                    fs.deleteFile(file);
+                }
             }
-
-            if(folder.label) {
-                meta.label = folder.label;
-            }
-
-            if(folder.tags) {
-                meta.tags = folder.tags;
-            }
-
-            logger.info("(AUTOADD) Adding torrent " + p.torrent.name + " from file " + file);
-
-            p.metadata = meta;
-            session.addTorrent(p);
-            if(!folder.keep) {
-                fs.deleteFile(file);
+            else {
+                logger.info("(AUTOADD) Could not read contents of file " + file);
             }
         }
     }


### PR DESCRIPTION
Fixes issue #183.
When a file path with non-ANSII characters was passed from Hadouken to a Javascript function, it was not being properly converted from UTF-16 to UTF-8 on Windows. This lead to the file path being corrupted and unable to be used when the Javascript function tried to open it. By using Boost's path functions and facets to automatically convert all file paths into and out of UTF-8 as needed, non-ANSII file paths can properly travel to and from Javascript on all platforms.
Boost's fstream functions are used to open files because STL's fstreams cannot handle UTF-8 on Windows and the UTF-16 overloads provided by Visual Studio are non-standard.

Tested on Windows and OS X
