### PR TITLE
Relaunch Hadouken as administrator when installing/uninstalling the service on Windows

### DIFF
--- a/include/hadouken/platform.hpp
+++ b/include/hadouken/platform.hpp
@@ -17,9 +17,9 @@ namespace hadouken
         static void init();
 
 #ifdef WIN32
-        static void install_service();
+        static void install_service(bool relaunch_if_needed);
 
-        static void uninstall_service();
+        static void uninstall_service(bool relaunch_if_needed);
 #endif
 
         static boost::filesystem::path data_path();


### PR DESCRIPTION
- Print a friendly error message and usage when the user passes an unknown parameter to Hadouken.
- When installing or uninstalling the Hadouken service on Windows, if the current user does not have permission to modify the service prompt the user to try again with an administrator account. This will display the UAC dialog to run as an administrator (for users with split tokens) or to enter an administrator's account credentials.
