### PR TITLE
Make service startup report failures to SCM

### DIFF
--- a/include/hadouken/hosting/console_host.hpp
+++ b/include/hadouken/hosting/console_host.hpp
@@ -11,7 +11,14 @@ namespace hadouken
         class console_host : public host
         {
         public:
-            int wait_for_exit(boost::shared_ptr<boost::asio::io_service> io);
+            int initialization_start(boost::shared_ptr<boost::asio::io_service> io);
+            int initialization_complete(int success_code);
+            int wait_for_exit();
+            int shutdown_start();
+            int shutdown_complete(int success_code);
+
+        private:
+            boost::shared_ptr<boost::asio::io_service> io_;
         };
     }
 }

--- a/include/hadouken/hosting/host.hpp
+++ b/include/hadouken/hosting/host.hpp
@@ -10,7 +10,11 @@ namespace hadouken
         class host
         {
         public:
-            virtual int wait_for_exit(boost::shared_ptr<boost::asio::io_service> io) = 0;
+            virtual int initialization_start(boost::shared_ptr<boost::asio::io_service> io) = 0;
+            virtual int initialization_complete(int success_code) = 0;
+            virtual int wait_for_exit() = 0;
+            virtual int shutdown_start() = 0;
+            virtual int shutdown_complete(int success_code) = 0;
         };
     }
 }

--- a/include/hadouken/hosting/service_host.hpp
+++ b/include/hadouken/hosting/service_host.hpp
@@ -12,20 +12,27 @@ namespace hadouken
         class service_host : public host
         {
         public:
-            int wait_for_exit(boost::shared_ptr<boost::asio::io_service> io);
+            service_host();
+
+            int initialization_start(boost::shared_ptr<boost::asio::io_service> io);
+            int initialization_complete(int success_code);
+            int wait_for_exit();
+            int shutdown_start();
+            int shutdown_complete(int success_code);
 
         protected:
             void service_main(DWORD argc, LPWSTR* argv);
             static DWORD WINAPI service_control_handler(DWORD control, DWORD event_type, LPVOID event_data, LPVOID context);
+            static DWORD WINAPI service_startup_threadproc(LPVOID lpParameter);
 
-            void set_status(DWORD state);
+            void set_status(DWORD state, DWORD exit_code = 0);
 
         private:
             static void WINAPI service_main_entry(DWORD argc, LPWSTR* argv);
 
             static service_host* instance_;
-            SERVICE_STATUS status_;
             SERVICE_STATUS_HANDLE status_handle_;
+            HANDLE startup_event_;
 
             boost::shared_ptr<boost::asio::signal_set> signals_;
             boost::shared_ptr<boost::asio::io_service> io_;

--- a/include/hadouken/platform.hpp
+++ b/include/hadouken/platform.hpp
@@ -28,7 +28,7 @@ namespace hadouken
 
         static boost::filesystem::path get_current_directory();
 
-        static int launch_process(std::string executable, std::vector<std::string> args);
+        static int launch_process(const std::string& executable, const std::vector<std::string>& args);
     };
 }
 

--- a/src/hosting/console_host.cpp
+++ b/src/hosting/console_host.cpp
@@ -2,16 +2,38 @@
 
 using namespace hadouken::hosting;
 
-int console_host::wait_for_exit(boost::shared_ptr<boost::asio::io_service> io)
+int console_host::initialization_start(boost::shared_ptr<boost::asio::io_service> io)
 {
-    boost::asio::signal_set signals(*io, SIGINT, SIGTERM);
+    io_ = io;
 
-    signals.async_wait([io](const boost::system::error_code& ec, int sig)
+    return EXIT_SUCCESS;
+}
+
+int console_host::initialization_complete(int success_code)
+{
+    return EXIT_SUCCESS;
+}
+
+int console_host::wait_for_exit()
+{
+    boost::asio::signal_set signals(*io_, SIGINT, SIGTERM);
+
+    signals.async_wait([this](const boost::system::error_code& ec, int sig)
     {
-        io->stop();
+        io_->stop();
     });
 
-    io->run();
+    io_->run();
 
-    return 0;
+    return EXIT_SUCCESS;
+}
+
+int console_host::shutdown_start()
+{
+    return EXIT_SUCCESS;
+}
+
+int console_host::shutdown_complete(int success_code)
+{
+    return EXIT_SUCCESS;
 }

--- a/src/hosting/service_host.cpp
+++ b/src/hosting/service_host.cpp
@@ -75,7 +75,7 @@ int service_host::wait_for_exit()
 {
     signals_->async_wait([this](const boost::system::error_code& error, int signal)
     {
-        BOOST_LOG_TRIVIAL(info) << "Service stopping";
+        BOOST_LOG_TRIVIAL(info) << "Service stopping: " << error.message();
         io_->stop();
         set_status(SERVICE_STOP_PENDING);
     });

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -64,6 +64,7 @@ std::unique_ptr<hadouken::hosting::host> get_host(const po::variables_map& optio
 int main(int argc, char *argv[])
 {
     desc.add_options()
+        ("help,h", "Display available commandline options")
         ("config", po::value<std::string>(), "Set path to a JSON configuration file. The default is %appdir%/hadouken.json")
         ("daemon", "Start Hadouken in daemon/service mode.")
 #ifdef WIN32
@@ -91,6 +92,13 @@ int main(int argc, char *argv[])
         return EXIT_FAILURE;
     }
 
+    // Print Help and exit if we get --help or -h on the command-line.
+    if (vm.count("help"))
+    {
+        std::cout << desc << std::endl;
+        return EXIT_SUCCESS;
+    }
+
     hadouken::logging::setup(vm);
 
     // Do platform-specific initialization as early as possible.
@@ -102,12 +110,12 @@ int main(int argc, char *argv[])
     if (vm.count("install-service"))
     {
         hadouken::platform::install_service(attempt_elevation);
-        return 0;
+        return EXIT_SUCCESS;
     }
     else if (vm.count("uninstall-service"))
     {
         hadouken::platform::uninstall_service(attempt_elevation);
-        return 0;
+        return EXIT_SUCCESS;
     }
 #endif
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -140,9 +140,35 @@ int main(int argc, char *argv[])
     app.script_host().define_global("__CONFIG__", config_file.string());
     app.script_host().define_global("__CONFIG_PATH__", config_file.parent_path().string());
 
-    app.start();
-    int result = get_host(vm)->wait_for_exit(io);
+    int result = EXIT_FAILURE;
+    std::unique_ptr<hadouken::hosting::host> host = get_host(vm);
+
+    result = host->initialization_start(io);
+    if (result == EXIT_SUCCESS)
+    {
+        try
+        {
+            app.start();
+        }
+        catch (std::exception& ex)
+        {
+            BOOST_LOG_TRIVIAL(fatal) << "Error starting Hadouken " << ex.what();
+            result = EXIT_FAILURE;
+        }
+    }
+
+    host->initialization_complete(result);
+
+    if (result == EXIT_SUCCESS)
+    {
+        result = host->wait_for_exit();
+    }
+
+    host->shutdown_start();
     app.stop();
+
+    // If running as a service, the process may be terminated at any time after calling this function
+    host->shutdown_complete(result);
 
     return result;
 }

--- a/src/platform_osx.cpp
+++ b/src/platform_osx.cpp
@@ -45,8 +45,8 @@ fs::path platform::get_current_directory()
     return fs::initial_path(); 
 }
 
-int platform::launch_process(std::string executable,
-                             std::vector<std::string> args) 
+int platform::launch_process(const std::string& executable,
+                             const std::vector<std::string>& args) 
 {
     return 0;
 }

--- a/src/platform_unix.cpp
+++ b/src/platform_unix.cpp
@@ -32,7 +32,7 @@ fs::path platform::get_current_directory()
     return fs::initial_path();
 }
 
-int platform::launch_process(std::string executable, std::vector<std::string> args)
+int platform::launch_process(const std::string& executable, const std::vector<std::string>& args)
 {
 }
 

--- a/src/platform_win32.cpp
+++ b/src/platform_win32.cpp
@@ -1,29 +1,27 @@
 #include <hadouken/platform.hpp>
 
-#include <atlstr.h>
 #include <boost/log/trivial.hpp>
 #include <windows.h>
 #include <shellapi.h>
 #include <shlobj.h>
 #include <shlwapi.h>
 #include <dbghelp.h>
-#include <tchar.h>
 
 using namespace hadouken;
 
-LONG WINAPI UnhandledException(LPEXCEPTION_POINTERS exceptionInfo)
+static LONG WINAPI UnhandledException(LPEXCEPTION_POINTERS exceptionInfo)
 {
-    TCHAR tempPath[MAX_PATH];
-    DWORD res = GetTempPath(MAX_PATH, tempPath);
+    WCHAR tempPath[MAX_PATH];
+    DWORD res = GetTempPath(ARRAYSIZE(tempPath), tempPath);
 
-    if (res > MAX_PATH || res == 0)
+    if (res > ARRAYSIZE(tempPath) || res == 0)
     {
         BOOST_LOG_TRIVIAL(error) << "Could not get temporary path for minidump.";
         return EXCEPTION_CONTINUE_SEARCH;
     }
 
-    TCHAR dmpPath[MAX_PATH + 2] = { 0 };
-    PathCombine(dmpPath, tempPath, TEXT("hadouken.dmp"));
+    WCHAR dmpPath[MAX_PATH + 2] = { 0 };
+    PathCombine(dmpPath, tempPath, L"hadouken.dmp");
 
     HANDLE file = CreateFile(dmpPath, GENERIC_READ | GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
 
@@ -52,7 +50,8 @@ LONG WINAPI UnhandledException(LPEXCEPTION_POINTERS exceptionInfo)
 
     return EXCEPTION_EXECUTE_HANDLER;
 }
-DWORD relaunch_as_different_user(LPCWSTR path, LPCWSTR parameters)
+
+static DWORD relaunch_as_different_user(LPCWSTR path, LPCWSTR parameters)
 {
     SHELLEXECUTEINFOW info = { 0 };
     info.cbSize = sizeof(SHELLEXECUTEINFO);
@@ -73,6 +72,22 @@ DWORD relaunch_as_different_user(LPCWSTR path, LPCWSTR parameters)
     }
 }
 
+static std::wstring utf8_to_utf16(const std::string& input)
+{
+    std::wstring output;
+    int size = MultiByteToWideChar(CP_UTF8, 0, input.c_str(), input.size(), NULL, 0);
+    if (size > 0)
+    {
+        output.resize(size);
+
+        size = MultiByteToWideChar(CP_UTF8, 0, input.c_str(), input.size(), &output[0], size);
+    }
+
+    output.resize(size);
+
+    return output;
+}
+
 void platform::init()
 {
     SetUnhandledExceptionFilter(UnhandledException);
@@ -80,9 +95,9 @@ void platform::init()
 
 void platform::install_service(bool relaunch_if_needed)
 {
-    wchar_t path[MAX_PATH] = { 0 };
+    WCHAR path[MAX_PATH] = { 0 };
 
-    if (!GetModuleFileName(NULL, path, MAX_PATH))
+    if (!GetModuleFileName(NULL, path, ARRAYSIZE(path)))
     {
         BOOST_LOG_TRIVIAL(error) << "Could not get filename.";
         return;
@@ -158,9 +173,9 @@ void platform::uninstall_service(bool relaunch_if_needed)
         DWORD errorCode = GetLastError();
         if (errorCode == ERROR_ACCESS_DENIED)
         {
-            wchar_t path[MAX_PATH] = { 0 };
+            WCHAR path[MAX_PATH] = { 0 };
 
-            if (!GetModuleFileName(NULL, path, MAX_PATH))
+            if (!GetModuleFileName(NULL, path, ARRAYSIZE(path)))
             {
                 BOOST_LOG_TRIVIAL(error) << "Could not get filename.";
                 return;
@@ -216,13 +231,15 @@ void platform::uninstall_service(bool relaunch_if_needed)
 
 boost::filesystem::path platform::data_path()
 {
-    TCHAR szPath[MAX_PATH];
-    HRESULT result = SHGetFolderPath(NULL, CSIDL_COMMON_APPDATA, NULL, 0, szPath);
+    WCHAR* szPath;
+    HRESULT result = SHGetKnownFolderPath(FOLDERID_ProgramData, 0, NULL, &szPath);
 
     if (SUCCEEDED(result))
     {
         boost::filesystem::path programData(szPath);
         programData /= "Hadouken";
+
+        CoTaskMemFree(szPath);
 
         return programData;
     }
@@ -232,21 +249,21 @@ boost::filesystem::path platform::data_path()
 
 boost::filesystem::path platform::application_path()
 {
-    TCHAR szPath[MAX_PATH];
-    GetModuleFileName(NULL, szPath, sizeof(szPath));
+    WCHAR szPath[MAX_PATH];
+    GetModuleFileName(NULL, szPath, ARRAYSIZE(szPath));
 
     return boost::filesystem::path(szPath).parent_path();
 }
 
 boost::filesystem::path platform::get_current_directory()
 {
-    TCHAR buffer[MAX_PATH];
-    GetCurrentDirectory(MAX_PATH, buffer);
+    WCHAR buffer[MAX_PATH];
+    GetCurrentDirectory(ARRAYSIZE(buffer), buffer);
 
     return boost::filesystem::path(buffer);
 }
 
-int platform::launch_process(std::string executable, std::vector<std::string> args)
+int platform::launch_process(const std::string& executable, const std::vector<std::string>& args)
 {
     STARTUPINFO startInfo = { sizeof(STARTUPINFO) };
     PROCESS_INFORMATION procInfo;
@@ -258,11 +275,10 @@ int platform::launch_process(std::string executable, std::vector<std::string> ar
         cmd.append(" " + arg);
     }
 
-    TCHAR p[4096];
-    _tcscpy_s(p, CA2T(cmd.c_str()));
+    std::wstring p = utf8_to_utf16(cmd);
 
     if (!CreateProcess(NULL,
-        p,
+        &p[0],
         NULL,
         NULL,
         TRUE,

--- a/src/scripting/modules/bencoding_module.cpp
+++ b/src/scripting/modules/bencoding_module.cpp
@@ -13,7 +13,7 @@ using namespace hadouken::scripting::modules::bittorrent;
 
 duk_ret_t bencoding_module::initialize(duk_context* ctx)
 {
-    duk_function_list_entry functions[] =
+    static duk_function_list_entry functions[] =
     {
         { "decode", decode, 1 },
         { "encode", encode, 1 },

--- a/src/scripting/modules/bittorrent/entry_wrapper.cpp
+++ b/src/scripting/modules/bittorrent/entry_wrapper.cpp
@@ -12,7 +12,7 @@ void entry_wrapper::initialize(duk_context* ctx, libtorrent::entry& entry)
 {
     duk_idx_t entryIndex = duk_push_object(ctx);
 
-    duk_function_list_entry functions[] =
+    static duk_function_list_entry functions[] =
     {
         { NULL, NULL, 0 }
     };

--- a/src/scripting/modules/bittorrent/feed_handle_wrapper.cpp
+++ b/src/scripting/modules/bittorrent/feed_handle_wrapper.cpp
@@ -11,7 +11,7 @@ using namespace hadouken::scripting::modules::bittorrent;
 
 void feed_handle_wrapper::initialize(duk_context* ctx, const libtorrent::feed_handle& handle)
 {
-    duk_function_list_entry functions[] =
+    static duk_function_list_entry functions[] =
     {
         { "updateFeed",  update_feed,     0 },
         { "getStatus",   get_feed_status, 0 },

--- a/src/scripting/modules/bittorrent/feed_status_wrapper.cpp
+++ b/src/scripting/modules/bittorrent/feed_status_wrapper.cpp
@@ -12,7 +12,7 @@ void feed_status_wrapper::initialize(duk_context* ctx, const libtorrent::feed_st
 {
     duk_idx_t idx = duk_push_object(ctx);
 
-    duk_function_list_entry functions[] =
+    static duk_function_list_entry functions[] =
     {
         { "getItems", get_items, 0 },
         { NULL,       NULL,      0 }

--- a/src/scripting/modules/bittorrent/lazy_entry_wrapper.cpp
+++ b/src/scripting/modules/bittorrent/lazy_entry_wrapper.cpp
@@ -12,7 +12,7 @@ void lazy_entry_wrapper::initialize(duk_context* ctx, libtorrent::lazy_entry& en
 {
     duk_idx_t entryIndex = duk_push_object(ctx);
 
-    duk_function_list_entry functions[] =
+    static duk_function_list_entry functions[] =
     {
         { NULL, NULL, 0 }
     };

--- a/src/scripting/modules/bittorrent/peer_info_wrapper.cpp
+++ b/src/scripting/modules/bittorrent/peer_info_wrapper.cpp
@@ -10,7 +10,7 @@ using namespace hadouken::scripting::modules::bittorrent;
 
 void peer_info_wrapper::initialize(duk_context* ctx, libtorrent::peer_info& peer)
 {
-    duk_function_list_entry functions[] =
+    static duk_function_list_entry functions[] =
     {
         { NULL, NULL, 0 }
     };

--- a/src/scripting/modules/bittorrent/session_wrapper.cpp
+++ b/src/scripting/modules/bittorrent/session_wrapper.cpp
@@ -32,7 +32,7 @@ void session_wrapper::initialize(duk_context* ctx, libtorrent::session& session)
     DUK_READONLY_PROPERTY(ctx, sessionIndex, sslListenPort, get_ssl_listen_port);
 
     // Session functions
-    duk_function_list_entry functions[] =
+    static duk_function_list_entry functions[] =
     {
         { "addDhtRouter",   add_dht_router, 2 },
         { "addFeed",        add_feed,       1 },
@@ -249,7 +249,7 @@ duk_ret_t session_wrapper::get_torrents(duk_context* ctx)
     int arrayIndex = duk_push_array(ctx);
     int i = 0;
 
-    for (libtorrent::torrent_handle handle : sess->get_torrents())
+    for (const libtorrent::torrent_handle& handle : sess->get_torrents())
     {
         torrent_handle_wrapper::initialize(ctx, handle);
         duk_put_prop_index(ctx, arrayIndex, i);

--- a/src/scripting/modules/bittorrent/torrent_creator_wrapper.cpp
+++ b/src/scripting/modules/bittorrent/torrent_creator_wrapper.cpp
@@ -19,7 +19,7 @@ duk_ret_t torrent_creator_wrapper::construct(duk_context* ctx)
 
     common::set_pointer<libtorrent::create_torrent>(ctx, -2, creator);
 
-    duk_function_list_entry functions[] =
+    static duk_function_list_entry functions[] =
     {
         { "generate", generate, 0 },
         { NULL, NULL, 0 }

--- a/src/scripting/modules/bittorrent/torrent_handle_wrapper.cpp
+++ b/src/scripting/modules/bittorrent/torrent_handle_wrapper.cpp
@@ -17,7 +17,7 @@ torrent_handle_wrapper::metadata_map_t torrent_handle_wrapper::metadata_ = torre
 
 void torrent_handle_wrapper::initialize(duk_context* ctx, const libtorrent::torrent_handle& handle)
 {
-    duk_function_list_entry functions[] =
+    static duk_function_list_entry functions[] =
     {
         { "clearError",        clear_error,         0 },
         { "flushCache",        flush_cache,         0 },

--- a/src/scripting/modules/bittorrent/torrent_info_wrapper.cpp
+++ b/src/scripting/modules/bittorrent/torrent_info_wrapper.cpp
@@ -50,7 +50,7 @@ duk_ret_t torrent_info_wrapper::construct(duk_context* ctx)
 
 void torrent_info_wrapper::initialize(duk_context* ctx, const libtorrent::torrent_info& info)
 {
-    duk_function_list_entry functions[] =
+    static duk_function_list_entry functions[] =
     {
         { "getFiles", get_files, 0 },
         { NULL, NULL, 0 }

--- a/src/scripting/modules/file_system_module.cpp
+++ b/src/scripting/modules/file_system_module.cpp
@@ -6,7 +6,6 @@
 #include <boost/log/trivial.hpp>
 #include <boost/scoped_array.hpp>
 
-#include <sstream>
 #include <functional>
 #include <memory>
 
@@ -33,6 +32,12 @@ size_t read_impl(const fs::path& path, std::function<char*(size_t)> alloc)
             file.read(buffer, size);
 
             return size;
+        }
+        else
+        {
+            BOOST_LOG_TRIVIAL(error) << "File does not exist: " << path.c_str();
+
+            return 0;
         }
     }
     catch (boost::filesystem::filesystem_error& ex)

--- a/src/scripting/modules/file_system_module.cpp
+++ b/src/scripting/modules/file_system_module.cpp
@@ -68,7 +68,7 @@ size_t write_impl(const fs::path& path, const char* data, size_t size)
 
 duk_ret_t file_system_module::initialize(duk_context* ctx)
 {
-    duk_function_list_entry functions[] =
+    static duk_function_list_entry functions[] =
     {
         { "combine",           combine,            DUK_VARARGS },
         { "createDirectories", create_directories, 1 },

--- a/src/scripting/modules/http_module.cpp
+++ b/src/scripting/modules/http_module.cpp
@@ -17,7 +17,7 @@ client_t;
 
 duk_ret_t http_module::initialize(duk_context* ctx)
 {
-    duk_function_list_entry functions[] =
+    static duk_function_list_entry functions[] =
     {
         { "post", post, 3 },
         { NULL,   NULL, 0 }

--- a/src/scripting/modules/logger_module.cpp
+++ b/src/scripting/modules/logger_module.cpp
@@ -7,7 +7,7 @@ using namespace hadouken::scripting::modules;
 
 duk_ret_t logger_module::initialize(duk_context* ctx)
 {
-    duk_function_list_entry functions[] =
+    static duk_function_list_entry functions[] =
     {
         { "get", get, 1 },
         { NULL, NULL, 0 }
@@ -23,7 +23,7 @@ duk_ret_t logger_module::get(duk_context* ctx)
 
     duk_idx_t logIdx = duk_push_object(ctx);
 
-    duk_function_list_entry functions[] =
+    static duk_function_list_entry functions[] =
     {
         { "trace", log_trace, DUK_VARARGS },
         { "debug", log_debug, DUK_VARARGS },

--- a/src/scripting/modules/process_module.cpp
+++ b/src/scripting/modules/process_module.cpp
@@ -8,7 +8,7 @@ using namespace hadouken::scripting::modules;
 
 duk_ret_t process_module::initialize(duk_context* ctx)
 {
-    duk_function_list_entry functions[] =
+    static duk_function_list_entry functions[] =
     {
         { "launch", launch, 2 },
         { NULL,     NULL,   0 }


### PR DESCRIPTION
In cases like issue #212, the service can fail to start for reasons
such as the configured port is already in use. Under the old service
startup model this meant Hadouken would die and the SCM would
eventually time out the start, reporting a generic failure message.

With this change the SCM is contacted earlier in the startup process,
before things really start running, putting the service in a pending
state. Only after Hadouken starts listening for requests does the
service move into the started state. If a failure happens during this
process the service moves from pending to stopping and provides an
error code to the SCM. In all cases the Hadouken service should no
longer time out.

Also includes other minor code changes such as passing strings by ref
rather than copy, marking functions as static, replacing ATL string conversion
functions with Win32 calls, and making the duk function lists static so they aren't
recreated every time the initialize function is called.
