### PR TITLE
Add advanced settings for active torrent limits

### DIFF
--- a/include/hadouken/scripting/modules/bittorrent/session_settings_wrapper.hpp
+++ b/include/hadouken/scripting/modules/bittorrent/session_settings_wrapper.hpp
@@ -49,6 +49,10 @@ namespace hadouken
                     DUK_PROP(mixed_mode_algorithm);
                     DUK_PROP(half_open_limit);
                     DUK_PROP(anonymous_mode);
+                    DUK_PROP(active_downloads);
+                    DUK_PROP(active_seeds);
+                    DUK_PROP(active_limit);
+                    DUK_PROP(dont_count_slow_torrents);
                 };
             }
         }

--- a/js/rpc/webui_getSettings.js
+++ b/js/rpc/webui_getSettings.js
@@ -79,7 +79,11 @@ exports.rpc = {
                 [ "bt.allow_same_ip", TYPE.BOOLEAN, settings.allowMultipleConnectionsPerIp.toString(), ACCESS.READWRITE ],
                 [ "bt.anonymous_mode", TYPE.BOOLEAN, settings.anonymousMode.toString(), ACCESS.READWRITE ],
                 get("bittorrent.utp.enabled", "net.enable_utp", TYPE.BOOLEAN, "true", ACCESS.READWRITE),
-                [ "net.max_halfopen", TYPE.NUMBER, (settings.halfOpenLimit >= 2147483647 ? -1 : settings.halfOpenLimit).toString(), ACCESS.READWRITE ]
+                [ "net.max_halfopen", TYPE.NUMBER, (settings.halfOpenLimit >= 2147483647 ? -1 : settings.halfOpenLimit).toString(), ACCESS.READWRITE ],
+                get("bittorrent.activeDownloads", "bt.active_downloads", TYPE.NUMBER, (settings.activeDownloads > 2147483647 ? -1 : settings.activeDownloads).toString(), ACCESS.READWRITE ),
+                get("bittorrent.activeSeeds", "bt.active_seeds", TYPE.NUMBER, (settings.activeSeeds > 2147483647 ? -1 : settings.activeSeeds).toString(), ACCESS.READWRITE ),
+                get("bittorrent.activeLimit", "bt.active_limit", TYPE.NUMBER, (settings.activeLimit > 2147483647 ? -1 : settings.activeLimit).toString(), ACCESS.READWRITE ),
+                get("bittorrent.dontCountSlowTorrents", "bt.dont_count_slow_torrents", TYPE.BOOLEAN, "true", ACCESS.READWRITE )
             ]
         };
     }

--- a/js/rpc/webui_setSettings.js
+++ b/js/rpc/webui_setSettings.js
@@ -1,5 +1,5 @@
 var config  = require("config");
-var session = require("bittorrent").session; 
+var session = require("bittorrent").session;
 
 function set(key, value) {
     var settings = session.getSettings();
@@ -12,6 +12,36 @@ function set(key, value) {
             }
             config.set("bittorrent.listenPort", port);
             session.listenOn([port, port]);
+            break;
+            
+        case "bt.active_downloads":
+            value = parseInt(value, 10);
+            if(!isNaN(value)) {
+                config.set("bittorrent.activeDownloads", value);
+                settings.activeDownloads = value;
+            }
+            break;
+            
+        case "bt.active_seeds":
+            value = parseInt(value, 10);
+            if(!isNaN(value)) {
+                config.set("bittorrent.activeSeeds", value);
+                settings.activeSeeds = value;
+            }
+            break;
+            
+        case "bt.active_limit":
+            value = parseInt(value, 10);
+            if(!isNaN(value)) {
+                config.set("bittorrent.activeLimit", value);
+                settings.activeLimit = value;
+            }
+            break;
+            
+        case "bt.dont_count_slow_torrents":
+            value = !!(value);
+            config.set("bittorrent.dontCountSlowTorrents", value);
+            settings.dontCountSlowTorrents = value;
             break;
 
         case "bt.anonymous_mode":

--- a/src/application.cpp
+++ b/src/application.cpp
@@ -43,6 +43,15 @@ void application::start()
     session_->add_extension(&libtorrent::create_ut_metadata_plugin);
     session_->add_extension(&libtorrent::create_ut_pex_plugin);
 
+    // User-configured bittorrent settings
+    auto settings = session_->settings();
+    settings.active_downloads = config_.get("bittorrent.activeDownloads", settings.active_downloads);
+    settings.active_seeds = config_.get("bittorrent.activeSeeds", settings.active_seeds);
+    settings.active_limit = config_.get("bittorrent.activeLimit", settings.active_limit);
+    settings.dont_count_slow_torrents = config_.get("bittorrent.dontCountSlowTorrents", settings.dont_count_slow_torrents);
+
+    session_->set_settings(settings);
+
     // load scripting host
     fs::path defaultPath = (hadouken::platform::application_path() / "js");
     fs::path scriptPath = config_.get<std::string>("scripting.path", defaultPath.string());

--- a/src/scripting/modules/bittorrent/session_settings_wrapper.cpp
+++ b/src/scripting/modules/bittorrent/session_settings_wrapper.cpp
@@ -46,7 +46,7 @@
     duk_ret_t session_settings_wrapper::set_##prop(duk_context* ctx) \
                 { \
         libtorrent::session_settings* ss = common::get_pointer<libtorrent::session_settings>(ctx); \
-        ss->prop = duk_require_boolean(ctx, 0); \
+        ss->prop = !!duk_require_boolean(ctx, 0); \
         return 0; \
                 }
 
@@ -81,6 +81,10 @@ void session_settings_wrapper::initialize(duk_context* ctx, libtorrent::session_
     DUK_READWRITE_PROPERTY(ctx, idx, mixedModeAlgorithm, mixed_mode_algorithm);
     DUK_READWRITE_PROPERTY(ctx, idx, halfOpenLimit, half_open_limit);
     DUK_READWRITE_PROPERTY(ctx, idx, anonymousMode, anonymous_mode);
+    DUK_READWRITE_PROPERTY(ctx, idx, activeDownloads, active_downloads);
+    DUK_READWRITE_PROPERTY(ctx, idx, activeSeeds, active_seeds);
+    DUK_READWRITE_PROPERTY(ctx, idx, activeLimit, active_limit);
+    DUK_READWRITE_PROPERTY(ctx, idx, dontCountSlowTorrents, dont_count_slow_torrents);
 
     // Set finalizer
     duk_push_c_function(ctx, finalize, 1);
@@ -116,3 +120,7 @@ DUK_INT_PROP(connections_limit)
 DUK_INT_PROP(mixed_mode_algorithm)
 DUK_INT_PROP(half_open_limit);
 DUK_BOOL_PROP(anonymous_mode);
+DUK_INT_PROP(active_downloads);
+DUK_INT_PROP(active_seeds);
+DUK_INT_PROP(active_limit);
+DUK_BOOL_PROP(dont_count_slow_torrents);


### PR DESCRIPTION
Add libtorrent settings active_downloads, active_seeds, active_limit,
and dont_count_slow_torrents to the advanced dialog and config.
Addresses issue #260.
